### PR TITLE
Shot Animation implemented

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -19,7 +19,9 @@ void Board::register_tank() {
       mStore.get_texture(one_of("tankDark_barrel2_outline.png", "tankRed_barrel2_outline.png",
                                 "tankGreen_barrel2_outline.png", "tankBlue_barrel2_outline.png"));
   tower_texture.setSmooth(true);
-  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture);
+  auto& shot_texture = mStore.get_texture("shotOrange.png");
+  shot_texture.setSmooth(true);
+  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture);
   tank.set_rotation(180);
   mTanks.push_back(std::move(tank));
 }
@@ -45,6 +47,9 @@ void Board::run() {
       keyboard_controller.update(event);
     }
 
+    for (auto& tank : mTanks) {
+      tank.update();
+    }
     mWindow.clear();
     mBackground.draw(mWindow);
     for (auto& tank : mTanks) {

--- a/src/KeyboardController.cpp
+++ b/src/KeyboardController.cpp
@@ -53,6 +53,7 @@ void KeyboardController::update(const sf::Event& event) {
       mLastShot = now;
       mBoard.fire_missle(mTank.get_tower_rotation(), mTank.get_position().x,
                          mTank.get_position().y);
+      mTank.shot();
     }
   }
 }

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <chrono>
 
 #include "TextureStore.hpp"
 
 enum class Rotation { None, Clockwise, Counterclockwise };
+inline constexpr int shotAnimationDistance = 30;
+inline constexpr std::chrono::milliseconds shotAnimationDuration = std::chrono::milliseconds(100);
 
 class TankPart {
  public:
@@ -14,16 +17,16 @@ class TankPart {
   void set_rotation(const int angle);
   void draw(sf::RenderWindow& window, const float x, const float y);
   float get_rotation() const;
+  void update();
 
  private:
-  void update();
   sf::Sprite mSprite;
   Rotation mRotation = Rotation::None;
 };
 
 class Tank {
  public:
-  Tank(float x, float y, sf::Texture& body, sf::Texture& tower);
+  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot);
 
   void rotate_body(Rotation r);
   void rotate_tower(Rotation r);
@@ -32,15 +35,22 @@ class Tank {
 
   void draw(sf::RenderWindow& draw);
   void set_current_speed(float speed);
+  void update();
+  void shot();
   sf::Vector2f get_position();
 
  private:
   inline constexpr static float M_SPEED = 0.01f;
-  void update();
+  void update_shot();
+  void update_position();
+  void draw_shot(sf::RenderWindow& draw);
 
   sf::Vector2f mPos;
   float mCurrentSpeed = 0.0f;
+  std::chrono::system_clock::time_point mShotStart;
+  bool mDrawShot = false;
 
   TankPart mBody;
   TankPart mTower;
+  TankPart mShot;
 };

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -13,11 +13,14 @@ static sf::Texture create_dummy_texture() {
 
 struct TankTest : ::testing::Test {
   TankTest()
-      : mBody(create_dummy_texture()), mTower(create_dummy_texture()), mTank(0, 0, mBody, mTower) {}
+      : mBody(create_dummy_texture()),
+        mTower(create_dummy_texture()),
+        mShot(create_dummy_texture()),
+        mTank(0, 0, mBody, mTower, mShot) {}
 
   sf::Texture mBody;
   sf::Texture mTower;
-  sf::RenderWindow dummy;
+  sf::Texture mShot;
   Tank mTank;
 };
 
@@ -31,66 +34,66 @@ void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs) {
 TEST_F(TankTest, SetSpeed_ShouldMoveUp) {
   expect_vec2f_eq(mTank.get_position(), {0.f, 0.f});
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {0.f, -10.f});
 }
 
-TEST_F(TankTest, Rotate90Degree_ShouldMoveLeft) {
+TEST_F(TankTest, Rotate90Degree_ShouldMoveRight) {
   mTank.set_rotation(90);
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {10.f, 0.f});
 }
 
 TEST_F(TankTest, Rotate180Degree_ShouldMoveDown) {
   mTank.set_rotation(180);
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {0.f, 10.f});
 }
 
 TEST_F(TankTest, Rotate270Degree_ShouldMoveLeft) {
   mTank.set_rotation(270);
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {-10.f, 0.f});
 }
 
 TEST_F(TankTest, MoveUpAndDown_ShouldReturnSamePos) {
   expect_vec2f_eq(mTank.get_position(), {0.f, 0.f});
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_current_speed(-10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {0.f, 0.f});
 }
 
 TEST_F(TankTest, MoveTurn180Move_ShouldReturn) {
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
 
   mTank.set_rotation(180);
-  mTank.draw(dummy);
+  mTank.update();
   expect_vec2f_eq(mTank.get_position(), {0.f, 0.f});
 }
 
 TEST_F(TankTest, MoveSquare_ShouldReturnToStart) {
   mTank.set_current_speed(10.0f);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_rotation(90);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_rotation(180);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_rotation(270);
-  mTank.draw(dummy);
+  mTank.update();
 
   expect_vec2f_eq(mTank.get_position(), {0.f, 0.f});
 }
 
-TEST_F(TankTest, RotateTower_ShoudntAffectMoving) {
+TEST_F(TankTest, RotateTower_ShouldntAffectMoving) {
   mTank.set_current_speed(10.0f);
   mTank.rotate_tower(Rotation::Clockwise);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.rotate_tower(Rotation::Counterclockwise);
 
   expect_vec2f_eq(mTank.get_position(), {0.f, -10.f});
@@ -99,13 +102,13 @@ TEST_F(TankTest, RotateTower_ShoudntAffectMoving) {
 TEST_F(TankTest, RotateBody_ShouldAffectMoving) {
   mTank.set_current_speed(10.0f);
   mTank.rotate_body(Rotation::Counterclockwise);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_current_speed(-10.0f);
   mTank.rotate_body(Rotation::Counterclockwise);
-  mTank.draw(dummy);
+  mTank.update();
   mTank.set_current_speed(10.0f);
   mTank.rotate_body(Rotation::Counterclockwise);
-  mTank.draw(dummy);
+  mTank.update();
 
   const auto [x, y] = mTank.get_position();
   EXPECT_PRED_FORMAT2(testing::FloatLE, x, 0.f);


### PR DESCRIPTION
New method Tank::shot() which sets the flag and starts the clock responsible for drawing shot on the map. If time elapsed is greater than threshold the flag is set to false.

Tank requires new texture in the constructor, which is responsible for
shot animation.

It is possible to configure shot animation by 2 variables defined in
tank.hpp:
- shot animation distance (how far the animation is from the barrel)
- shot animation duration (how long will the animation be displayed)

Code restructure to honour Single Responsibility Principle (draw function
does not update objects any more). Because of this change it was
necessary to update TankTests aswell. Dummy RenderWindow is no longer
necessary in tests.