### PR TITLE
Tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 **/.DS_Store
+.vscode
+build
+lib
+vcpkg_installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(tank_bot_fight_lib STATIC
     src/Random.cpp
     src/SquareRootEngine.cpp
     src/TracesHandler.cpp
+    src/Trace.cpp
 )
 
 target_include_directories(tank_bot_fight_lib PRIVATE src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(tank_bot_fight_lib STATIC
     src/Obstacle.cpp
     src/Random.cpp
     src/SquareRootEngine.cpp
+    src/TracesHandler.cpp
 )
 
 target_include_directories(tank_bot_fight_lib PRIVATE src)

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -28,7 +28,7 @@ void Board::register_tank() {
   tracks_texture.setSmooth(true);
   tracks_texture.setRepeated(true);
   auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_texture,
-                   std::make_unique<SquareRootEngine>(70, 5),
+                   std::make_unique<SquareRootEngine>(70, 5.f),
                    TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f});
   tank.set_rotation(180);
   mTanks.emplace_back(std::move(tank));

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -6,6 +6,8 @@
 #include "KeyboardController.hpp"
 #include "Random.hpp"
 #include "Size.hpp"
+#include "SquareRootEngine.hpp"
+#include "TracesHandler.hpp"
 
 Board::Board() : mWindow(sf::VideoMode(WIDTH, HEIGHT), "TankBotFight"), mBackground(mStore) {
   mWindow.setFramerateLimit(30);
@@ -26,7 +28,8 @@ void Board::register_tank() {
   tracks_texture.setSmooth(true);
   tracks_texture.setRepeated(true);
   auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_texture,
-                   std::make_unique<SquareRootEngine>(70, 5));
+                   std::make_unique<SquareRootEngine>(70, 5),
+                   TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f});
   tank.set_rotation(180);
   mTanks.emplace_back(std::move(tank));
   mFont.loadFromFile(files::asset_path() + "DejaVuSans.ttf");

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -22,9 +22,9 @@ void Board::register_tank() {
   tower_texture.setSmooth(true);
   auto& shot_texture = mStore.get_texture("shotOrange.png");
   shot_texture.setSmooth(true);
-  auto& tracks_t = mStore.get_texture("tracksSmall.png");
-  tracks_t.setSmooth(true);
-  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_t,
+  auto& tracks_texture = mStore.get_texture("tracksSmall.png");
+  tracks_texture.setSmooth(true);
+  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_texture,
                    std::make_unique<SquareRootEngine>(70, 5));
   tank.set_rotation(180);
   mTanks.emplace_back(std::move(tank));
@@ -39,7 +39,12 @@ void Board::fire_missle(const int angle, const float x, const float y) {
 
 void Board::run() {
   KeyboardController keyboard_controller(mTanks[0], *this);
-
+  auto& tracks_texture = mStore.get_texture("tracksSmall.png");
+  tracks_texture.setSmooth(true);
+  sf::Sprite tracks(tracks_texture);
+  tracks.setPosition(100.f, 100.f);
+  tracks.setRotation(180.f);
+  int texHeight = 30;
   while (mWindow.isOpen()) {
     sf::Event event;
     while (mWindow.pollEvent(event)) {
@@ -49,6 +54,9 @@ void Board::run() {
 
       if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape) {
         mWindow.close();
+      }
+      if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::J) {
+        texHeight = (texHeight + 1) % 52;
       }
       keyboard_controller.update(event);
     }
@@ -64,6 +72,8 @@ void Board::run() {
     for (auto& missle : mMissles) {
       missle.draw(mWindow);
     }
+    tracks.setTextureRect({0, 0, 37, texHeight});
+    mWindow.draw(tracks);
     display_speed();
     remove_missles();
     mWindow.display();

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -22,8 +22,9 @@ void Board::register_tank() {
   tower_texture.setSmooth(true);
   auto& shot_texture = mStore.get_texture("shotOrange.png");
   shot_texture.setSmooth(true);
-  auto& tracks_texture = mStore.get_texture("tracksSmall.png");
+  auto& tracks_texture = mStore.get_texture("tracksSmall.png", {0, 0, 37, 48});
   tracks_texture.setSmooth(true);
+  tracks_texture.setRepeated(true);
   auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_texture,
                    std::make_unique<SquareRootEngine>(70, 5));
   tank.set_rotation(180);
@@ -39,12 +40,6 @@ void Board::fire_missle(const int angle, const float x, const float y) {
 
 void Board::run() {
   KeyboardController keyboard_controller(mTanks[0], *this);
-  auto& tracks_texture = mStore.get_texture("tracksSmall.png");
-  tracks_texture.setSmooth(true);
-  sf::Sprite tracks(tracks_texture);
-  tracks.setPosition(100.f, 100.f);
-  tracks.setRotation(180.f);
-  int texHeight = 30;
   while (mWindow.isOpen()) {
     sf::Event event;
     while (mWindow.pollEvent(event)) {
@@ -54,9 +49,6 @@ void Board::run() {
 
       if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape) {
         mWindow.close();
-      }
-      if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::J) {
-        texHeight = (texHeight + 1) % 52;
       }
       keyboard_controller.update(event);
     }
@@ -72,8 +64,6 @@ void Board::run() {
     for (auto& missle : mMissles) {
       missle.draw(mWindow);
     }
-    tracks.setTextureRect({0, 0, 37, texHeight});
-    mWindow.draw(tracks);
     display_speed();
     remove_missles();
     mWindow.display();

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -22,7 +22,9 @@ void Board::register_tank() {
   tower_texture.setSmooth(true);
   auto& shot_texture = mStore.get_texture("shotOrange.png");
   shot_texture.setSmooth(true);
-  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture,
+  auto& tracks_t = mStore.get_texture("tracksSmall.png");
+  tracks_t.setSmooth(true);
+  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_t,
                    std::make_unique<SquareRootEngine>(70, 5));
   tank.set_rotation(180);
   mTanks.emplace_back(std::move(tank));

--- a/src/Board.hpp
+++ b/src/Board.hpp
@@ -3,7 +3,6 @@
 #include <SFML/Graphics.hpp>
 
 #include "Missle.hpp"
-#include "SquareRootEngine.hpp"
 #include "Tank.hpp"
 #include "background/Background.hpp"
 

--- a/src/KeyboardController.cpp
+++ b/src/KeyboardController.cpp
@@ -3,8 +3,8 @@
 #include <SFML/Graphics.hpp>
 
 #include "Board.hpp"
-#include "Tank.hpp"
 #include "Engine.hpp"
+#include "Tank.hpp"
 
 KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {
   mLastShot = std::chrono::system_clock::now();

--- a/src/KeyboardController.cpp
+++ b/src/KeyboardController.cpp
@@ -4,6 +4,7 @@
 
 #include "Board.hpp"
 #include "Tank.hpp"
+#include "Engine.hpp"
 
 KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {
   mLastShot = std::chrono::system_clock::now();

--- a/src/SquareRootEngine.cpp
+++ b/src/SquareRootEngine.cpp
@@ -7,7 +7,7 @@
 #include "Size.hpp"
 #include "utility.hpp"
 
-SquareRootEngine::SquareRootEngine(const int step_count, const int max_speed)
+SquareRootEngine::SquareRootEngine(const int step_count, const float max_speed)
     : mStepCount(step_count), mMaxSpeed(max_speed) {}
 
 std::unique_ptr<Engine> SquareRootEngine::copy() const {

--- a/src/SquareRootEngine.hpp
+++ b/src/SquareRootEngine.hpp
@@ -4,7 +4,7 @@
 
 class SquareRootEngine : public Engine {
  public:
-  SquareRootEngine(const int step_count, const int max_speed);
+  SquareRootEngine(const int step_count, const float max_speed);
   void set_gear(const Gear gear) override;
   float get_current_speed() const override;
   sf::Vector2f get_position_delta(const float rotation_radians) override;

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -47,15 +47,15 @@ void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
 }
 
 Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture &shot,
-           sf::Texture &tracks, std::unique_ptr<Engine> &&engine, const int max_trace_age,
-           const float trace_decay_rate)
+           sf::Texture &tracks, std::unique_ptr<Engine> &&engine,
+           const TracesHandlerConfig &traces_handler_config)
     : mPos({x, y}),
       mBody(body),
       mTower(tower),
       mShot(shot),
       mEngine(std::move(engine)),
       mTracesHandler(std::make_unique<TracesHandler>(tracks, mBody.get_sprite(), mPos,
-                                                     max_trace_age, trace_decay_rate)) {
+                                                     traces_handler_config)) {
   set_rotation(180);
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
@@ -71,9 +71,9 @@ Tank::Tank(const Tank &rhs)
       mTower(rhs.mTower),
       mShot(rhs.mShot),
       mEngine(rhs.mEngine->copy()),
-      mTracesHandler(std::make_unique<TracesHandler>(
-          rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(), mPos,
-          rhs.mTracesHandler->get_max_trace_age(), rhs.mTracesHandler->get_trace_decay_rate())) {}
+      mTracesHandler(std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(),
+                                                     mBody.get_sprite(), mPos,
+                                                     rhs.mTracesHandler->get_config())) {}
 
 Tank::Tank(Tank &&rhs)
     : mPos(std::move(rhs.mPos)),
@@ -84,9 +84,9 @@ Tank::Tank(Tank &&rhs)
       mTower(std::move(rhs.mTower)),
       mShot(std::move(rhs.mShot)),
       mEngine(std::move(rhs.mEngine)),
-      mTracesHandler(std::make_unique<TracesHandler>(
-          rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(), mPos,
-          rhs.mTracesHandler->get_max_trace_age(), rhs.mTracesHandler->get_trace_decay_rate())) {}
+      mTracesHandler(std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(),
+                                                     mBody.get_sprite(), mPos,
+                                                     rhs.mTracesHandler->get_config())) {}
 
 Tank &Tank::operator=(const Tank &rhs) {
   if (this == &rhs) {
@@ -100,9 +100,9 @@ Tank &Tank::operator=(const Tank &rhs) {
   mTower = rhs.mTower;
   mShot = rhs.mShot;
   mEngine = rhs.mEngine->copy();
-  mTracesHandler = std::make_unique<TracesHandler>(
-      rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(), mPos,
-      rhs.mTracesHandler->get_max_trace_age(), rhs.mTracesHandler->get_trace_decay_rate());
+  mTracesHandler =
+      std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(),
+                                      mPos, rhs.mTracesHandler->get_config());
   return *this;
 }
 
@@ -118,9 +118,9 @@ Tank &Tank::operator=(Tank &&rhs) {
   mTower = std::move(rhs.mTower);
   mShot = std::move(rhs.mShot);
   mEngine = std::move(rhs.mEngine);
-  mTracesHandler = std::make_unique<TracesHandler>(
-      rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(), mPos,
-      rhs.mTracesHandler->get_max_trace_age(), rhs.mTracesHandler->get_trace_decay_rate());
+  mTracesHandler =
+      std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(),
+                                      mPos, rhs.mTracesHandler->get_config());
   return *this;
 }
 

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -1,6 +1,10 @@
 #include "Tank.hpp"
 
+#include <SFML/Graphics/Rect.hpp>
+#include <algorithm>
 #include <cmath>
+#include <numeric>
+#include <tuple>
 
 #include "Engine.hpp"
 #include "Size.hpp"
@@ -18,6 +22,8 @@ void TankPart::rotate(const Rotation r) { mRotation = r; }
 void TankPart::set_rotation(const int angle) { mSprite.setRotation(angle); }
 
 float TankPart::get_rotation() const { return mSprite.getRotation(); }
+
+sf::Sprite &TankPart::get_sprite() { return mSprite; }
 
 void TankPart::update() {
   switch (mRotation) {
@@ -38,8 +44,13 @@ void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
 }
 
 Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture &shot,
-           std::unique_ptr<Engine> &&engine)
-    : mPos({x, y}), mBody(body), mTower(tower), mShot(shot), mEngine(std::move(engine)) {
+           sf::Texture &tracks, std::unique_ptr<Engine> &&engine)
+    : mPos({x, y}),
+      mBody(body),
+      mTower(tower),
+      mShot(shot),
+      mTracks(tracks),
+      mEngine(std::move(engine)) {
   mTower.set_rotation(180);
   mShot.set_rotation(180);
 }
@@ -49,6 +60,7 @@ Tank::Tank(const Tank &rhs)
       mBody(rhs.mBody),
       mTower(rhs.mTower),
       mShot(rhs.mShot),
+      mTracks(rhs.mTracks),
       mEngine(rhs.mEngine->copy()) {}
 
 Tank &Tank::operator=(const Tank &rhs) {
@@ -62,13 +74,17 @@ Tank &Tank::operator=(const Tank &rhs) {
   mBody = rhs.mBody;
   mTower = rhs.mTower;
   mShot = rhs.mShot;
+  mTracks = rhs.mTracks;
   mEngine = rhs.mEngine->copy();
   return *this;
 }
 
 void Tank::set_gear(Gear gear) { mEngine->set_gear(gear); }
 
-void Tank::rotate_body(Rotation r) { mBody.rotate(r); }
+void Tank::rotate_body(Rotation r) {
+  mBody.rotate(r);
+  mTracks.rotate(r);
+}
 
 void Tank::rotate_tower(Rotation r) {
   mTower.rotate(r);
@@ -79,11 +95,14 @@ void Tank::set_rotation(const int angle) {
   mTower.set_rotation(angle);
   mBody.set_rotation(angle);
   mShot.set_rotation(angle);
+  mTracks.set_rotation(angle);
 }
 
 sf::Vector2f Tank::get_position() { return mPos; }
 
 void Tank::update() {
+  update_track_animations();
+
   mBody.update();
   mTower.update();
   mShot.update();
@@ -93,11 +112,33 @@ void Tank::update() {
   update_shot();
 }
 
+void Tank::update_track_animations() {
+  auto add_new_animation = [this](const sf::IntRect &texture_rect) {
+    mTracksAnimations.emplace_back(std::make_tuple(mPos, mBody.get_rotation(), texture_rect));
+  };
+
+  const auto &[x, y, width, height] = mTracks.get_sprite().getTextureRect();
+  const float distance = hypot(mEngine->get_position_delta(to_radians(mBody.get_rotation())));
+  if (mTracksAnimations.empty()) {
+    add_new_animation(sf::Rect{x, y, width, static_cast<int>(distance)});
+    return;
+  }
+  const auto &[newestPos, newestAngle, newestRect] = mTracksAnimations.back();
+  if (mBody.get_rotation() != newestAngle) {
+    add_new_animation(sf::Rect{x, y, width, static_cast<int>(distance)});
+  } else if (newestRect.height + distance > height) {
+    std::get<2>(mTracksAnimations.back()) = sf::Rect{x, y, width, height};
+    add_new_animation(sf::Rect{x, y, width, static_cast<int>(distance) % height});
+  } else {
+    // update existing texture height
+    // update animation starting position
+
+  }
+}
+
 void Tank::update_position() {
   mPos += mEngine->get_position_delta(to_radians(mBody.get_rotation()));
 }
-
-float Tank::get_current_speed() { return mEngine->get_current_speed(); }
 
 void Tank::update_shot() {
   auto now = std::chrono::system_clock::now();
@@ -107,6 +148,8 @@ void Tank::update_shot() {
   }
 }
 
+float Tank::get_current_speed() { return mEngine->get_current_speed(); }
+
 void Tank::shot() {
   mShotStart = std::chrono::system_clock::now();
   mDrawShot = true;
@@ -115,11 +158,22 @@ void Tank::shot() {
 float Tank::get_tower_rotation() const { return mTower.get_rotation(); }
 
 void Tank::draw(sf::RenderWindow &window) {
+  // sf::Vector2f positionDelta{};
+  // for (int i = 1; i < mPositionSnapshots.size(); i++) {
+  //   positionDelta += abs(mPositionSnapshots[i - 1].first - mPos);
+  //   // direction change
+  //   if (mPositionSnapshots[i - 1].second != mPositionSnapshots[i].second) {
+  //     positionDelta = abs(mPositionSnapshots[i - 1].first - mPos);
+  //   }
+  //   mTracks.setRotation(angle);
+  //   // window.draw(mTracks);
+  // }
   mBody.draw(window, mPos.x, mPos.y);
   mTower.draw(window, mPos.x, mPos.y);
   if (mDrawShot) {
     draw_shot(window);
   }
+  draw_tracks(window);
 }
 
 void Tank::draw_shot(sf::RenderWindow &window) {
@@ -130,4 +184,37 @@ void Tank::draw_shot(sf::RenderWindow &window) {
   };
   auto shotAnimationPosition = getShotAnimationPosition(mTower.get_rotation());
   mShot.draw(window, shotAnimationPosition.x, shotAnimationPosition.y);
+}
+
+void Tank::draw_tracks(sf::RenderWindow &window) {
+  // auto getTracksAnimations = [this]() {
+  //   std::tuple<sf::Vector2f, float, sf::Rect<int>> posAngleRect{};
+  //   std::vector<std::tuple<sf::Vector2f, float, sf::Rect<int>>> tracksAnimations{};
+  //   auto start = this->mPositionSnapshots.begin();
+  //   while (start != this->mPositionSnapshots.end()) {
+  //     const auto end = std::adjacent_find(
+  //         start, this->mPositionSnapshots.end(),
+  //         [](const auto &lhs, const auto &rhs) { return lhs.second != rhs.second; });
+  //     auto &[startPos, startAngle] = *start;
+  //     const float distance = hypot(startPos - end->first);
+  //     const auto &[x, y, width, height] = this->mTracks.get_sprite().getTextureRect();
+  //     for (int i = 0; i < distance / height; ++i) {
+  //       // dodajemy elementy ale przesuwamy pozycje
+  //       tracksAnimations.emplace_back(
+  //           std::make_tuple(startPos, start->second, sf::Rect{x, y, width, height}));
+  //       startPos = get_pos(startPos, height, startAngle);
+  //     }
+  //     tracksAnimations.emplace_back(std::make_tuple(
+  //         startPos, startAngle, sf::Rect{x, y, width, static_cast<int>(distance) % height}));
+
+  //     start = end;
+  //   }
+
+  //   return std::vector{posAngleRect};
+  // };
+  for (const auto &[pos, angle, rect] : mTracksAnimations) {
+    mTracks.set_rotation(angle);
+    mTracks.get_sprite().setTextureRect(rect);
+    mTracks.draw(window, pos.x, pos.y);
+  }
 }

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -16,7 +16,6 @@ TankPart::TankPart(sf::Texture &texture) {
   mSprite.setTexture(texture);
   const auto [width, height] = texture.getSize();
   mSprite.setOrigin(width / 2.f, height / 2.f);
-  std::cout << "TANKPART::TANKPART SPRITE ADDRESS: " << &mSprite << "\n";
 }
 
 void TankPart::rotate(const Rotation r) { mRotation = r; }
@@ -56,8 +55,6 @@ Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture 
       mTracks(tracks),
       mEngine(std::move(engine)),
       mTracesHandler(std::make_unique<TracesHandler>(tracks, mBody.get_sprite(), mPos)) {
-  std::cout << "TANK::TANK BODY SPRITE ADDRESS: " << &mBody.get_sprite() << "\n";
-  std::cout << "TANK::TANK TANK ADDRESS: " << this << "\n";
   set_rotation(180);
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
@@ -75,9 +72,7 @@ Tank::Tank(const Tank &rhs)
       mTracks(rhs.mTracks),
       mEngine(rhs.mEngine->copy()),
       mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(),
-                                                     mBody.get_sprite(), mPos)) {
-  std::cout << "TANK copy constructor\n";
-}
+                                                     mBody.get_sprite(), mPos)) {}
 
 Tank::Tank(Tank &&rhs)
     : mPos(std::move(rhs.mPos)),
@@ -90,14 +85,9 @@ Tank::Tank(Tank &&rhs)
       mTracks(std::move(rhs.mTracks)),
       mEngine(std::move(rhs.mEngine)),
       mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(),
-                                                     mBody.get_sprite(), mPos)) {
-  std::cout << "TANK::TANK MOVE CTOR BODY ADDRESS: " << &mBody.get_sprite() << "\n";
-  std::cout << "TANK::TANK MOVE CTOR TANK ADDRESS: " << this << "\n";
-}
+                                                     mBody.get_sprite(), mPos)) {}
 
 Tank &Tank::operator=(const Tank &rhs) {
-  std::cout << "TANK copy operator=\n";
-
   if (this == &rhs) {
     return *this;
   }
@@ -133,6 +123,8 @@ Tank &Tank::operator=(Tank &&rhs) {
   return *this;
 }
 
+Tank::~Tank() = default;
+
 void Tank::set_gear(Gear gear) { mEngine->set_gear(gear); }
 
 void Tank::rotate_body(Rotation r) {
@@ -159,12 +151,8 @@ void Tank::update() {
   mTower.update();
   mShot.update();
   mEngine->update();
-  // we have a position update; however tank elements are not yet updated
   update_position();
-  // std::cout << "TANK::UPDATE TANK POSITION: ";
-  // print_point(mBody.get_sprite().getPosition());
   mTracesHandler->update();
-
   update_shot();
 }
 
@@ -214,7 +202,7 @@ void Tank::draw_shot(sf::RenderWindow &window) {
 }
 
 void Tank::draw_tracks(sf::RenderWindow &window) {
-  for (const auto &sprite : mTracesHandler->getTraces()) {
+  for (const auto &sprite : mTracesHandler->get_traces()) {
     window.draw(sprite);
   }
 }

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -58,8 +58,11 @@ Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture 
       mTracesHandler(std::make_unique<TracesHandler>(tracks, mBody.get_sprite(), mPos)) {
   std::cout << "TANK::TANK BODY SPRITE ADDRESS: " << &mBody.get_sprite() << "\n";
   std::cout << "TANK::TANK TANK ADDRESS: " << this << "\n";
-  mTower.set_rotation(180);
-  mShot.set_rotation(180);
+  set_rotation(180);
+  mBody.get_sprite().setPosition(mPos);
+  mTower.get_sprite().setPosition(mPos);
+  mShot.get_sprite().setPosition(mPos);
+
 }
 
 Tank::Tank(const Tank &rhs)
@@ -153,6 +156,7 @@ void Tank::update() {
   mTower.update();
   mShot.update();
   mEngine->update();
+  // we have a position update; however tank elements are not yet updated
   update_position();
   // std::cout << "TANK::UPDATE TANK POSITION: ";
   // print_point(mBody.get_sprite().getPosition());
@@ -162,7 +166,9 @@ void Tank::update() {
 }
 
 void Tank::update_position() {
-  mPos += mEngine->get_position_delta(to_radians(mBody.get_rotation()));
+  const auto& delta = mEngine->get_position_delta(to_radians(mBody.get_rotation()));
+  mPos += delta;
+  
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
   mShot.get_sprite().setPosition(mPos);

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -101,8 +101,6 @@ void Tank::set_rotation(const int angle) {
 sf::Vector2f Tank::get_position() { return mPos; }
 
 void Tank::update() {
-  update_track_animations();
-
   mBody.update();
   mTower.update();
   mShot.update();
@@ -132,7 +130,6 @@ void Tank::update_track_animations() {
   } else {
     // update existing texture height
     // update animation starting position
-
   }
 }
 
@@ -158,22 +155,11 @@ void Tank::shot() {
 float Tank::get_tower_rotation() const { return mTower.get_rotation(); }
 
 void Tank::draw(sf::RenderWindow &window) {
-  // sf::Vector2f positionDelta{};
-  // for (int i = 1; i < mPositionSnapshots.size(); i++) {
-  //   positionDelta += abs(mPositionSnapshots[i - 1].first - mPos);
-  //   // direction change
-  //   if (mPositionSnapshots[i - 1].second != mPositionSnapshots[i].second) {
-  //     positionDelta = abs(mPositionSnapshots[i - 1].first - mPos);
-  //   }
-  //   mTracks.setRotation(angle);
-  //   // window.draw(mTracks);
-  // }
   mBody.draw(window, mPos.x, mPos.y);
   mTower.draw(window, mPos.x, mPos.y);
   if (mDrawShot) {
     draw_shot(window);
   }
-  draw_tracks(window);
 }
 
 void Tank::draw_shot(sf::RenderWindow &window) {
@@ -186,35 +172,4 @@ void Tank::draw_shot(sf::RenderWindow &window) {
   mShot.draw(window, shotAnimationPosition.x, shotAnimationPosition.y);
 }
 
-void Tank::draw_tracks(sf::RenderWindow &window) {
-  // auto getTracksAnimations = [this]() {
-  //   std::tuple<sf::Vector2f, float, sf::Rect<int>> posAngleRect{};
-  //   std::vector<std::tuple<sf::Vector2f, float, sf::Rect<int>>> tracksAnimations{};
-  //   auto start = this->mPositionSnapshots.begin();
-  //   while (start != this->mPositionSnapshots.end()) {
-  //     const auto end = std::adjacent_find(
-  //         start, this->mPositionSnapshots.end(),
-  //         [](const auto &lhs, const auto &rhs) { return lhs.second != rhs.second; });
-  //     auto &[startPos, startAngle] = *start;
-  //     const float distance = hypot(startPos - end->first);
-  //     const auto &[x, y, width, height] = this->mTracks.get_sprite().getTextureRect();
-  //     for (int i = 0; i < distance / height; ++i) {
-  //       // dodajemy elementy ale przesuwamy pozycje
-  //       tracksAnimations.emplace_back(
-  //           std::make_tuple(startPos, start->second, sf::Rect{x, y, width, height}));
-  //       startPos = get_pos(startPos, height, startAngle);
-  //     }
-  //     tracksAnimations.emplace_back(std::make_tuple(
-  //         startPos, startAngle, sf::Rect{x, y, width, static_cast<int>(distance) % height}));
-
-  //     start = end;
-  //   }
-
-  //   return std::vector{posAngleRect};
-  // };
-  for (const auto &[pos, angle, rect] : mTracksAnimations) {
-    mTracks.set_rotation(angle);
-    mTracks.get_sprite().setTextureRect(rect);
-    mTracks.draw(window, pos.x, pos.y);
-  }
-}
+void Tank::draw_tracks(sf::RenderWindow &window) {}

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -62,7 +62,6 @@ Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture 
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
   mShot.get_sprite().setPosition(mPos);
-
 }
 
 Tank::Tank(const Tank &rhs)
@@ -75,7 +74,8 @@ Tank::Tank(const Tank &rhs)
       mShot(rhs.mShot),
       mTracks(rhs.mTracks),
       mEngine(rhs.mEngine->copy()),
-      mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos)) {
+      mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(),
+                                                     mBody.get_sprite(), mPos)) {
   std::cout << "TANK copy constructor\n";
 }
 
@@ -89,10 +89,11 @@ Tank::Tank(Tank &&rhs)
       mShot(std::move(rhs.mShot)),
       mTracks(std::move(rhs.mTracks)),
       mEngine(std::move(rhs.mEngine)),
-      mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos)) {
-        std::cout << "TANK::TANK MOVE CTOR BODY ADDRESS: " << &mBody.get_sprite() << "\n";
-        std::cout << "TANK::TANK MOVE CTOR TANK ADDRESS: " << this << "\n";
-      }
+      mTracesHandler(std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(),
+                                                     mBody.get_sprite(), mPos)) {
+  std::cout << "TANK::TANK MOVE CTOR BODY ADDRESS: " << &mBody.get_sprite() << "\n";
+  std::cout << "TANK::TANK MOVE CTOR TANK ADDRESS: " << this << "\n";
+}
 
 Tank &Tank::operator=(const Tank &rhs) {
   std::cout << "TANK copy operator=\n";
@@ -109,7 +110,8 @@ Tank &Tank::operator=(const Tank &rhs) {
   mShot = rhs.mShot;
   mTracks = rhs.mTracks;
   mEngine = rhs.mEngine->copy();
-  mTracesHandler = std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos);
+  mTracesHandler =
+      std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos);
   return *this;
 }
 
@@ -126,7 +128,8 @@ Tank &Tank::operator=(Tank &&rhs) {
   mShot = std::move(rhs.mShot);
   mTracks = std::move(rhs.mTracks);
   mEngine = std::move(rhs.mEngine);
-  mTracesHandler = std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos);
+  mTracesHandler =
+      std::make_unique<TracesHandler>(*mTracks.get_sprite().getTexture(), mBody.get_sprite(), mPos);
   return *this;
 }
 
@@ -166,9 +169,9 @@ void Tank::update() {
 }
 
 void Tank::update_position() {
-  const auto& delta = mEngine->get_position_delta(to_radians(mBody.get_rotation()));
+  const auto &delta = mEngine->get_position_delta(to_radians(mBody.get_rotation()));
   mPos += delta;
-  
+
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
   mShot.get_sprite().setPosition(mPos);

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -1,10 +1,6 @@
 #include "Tank.hpp"
 
-#include <SFML/Graphics/Rect.hpp>
-#include <algorithm>
 #include <cmath>
-#include <numeric>
-#include <tuple>
 
 #include "Engine.hpp"
 #include "Size.hpp"

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -7,11 +7,13 @@
 #include <deque>
 #include <tuple>
 #include "TextureStore.hpp"
+#include "TracesHandler.hpp"
 
 enum class Rotation { None, Clockwise, Counterclockwise };
 inline constexpr int shotAnimationDistance = 30;
 inline constexpr std::chrono::milliseconds shotAnimationDuration = std::chrono::milliseconds(100);
 
+class TracesHandler;
 class Engine;
 enum class Gear;
 class TankPart {
@@ -23,6 +25,7 @@ class TankPart {
   void draw(sf::RenderWindow& window, const float x, const float y);
   float get_rotation() const;
   sf::Sprite& get_sprite();
+  const sf::Sprite& get_sprite() const;
   void update();
 
  private:
@@ -36,9 +39,9 @@ class Tank {
   Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot, sf::Texture& tracks,
        std::unique_ptr<Engine>&& engine);
   Tank(const Tank&);
-  Tank(Tank&&) = default;
+  Tank(Tank&&);
   Tank& operator=(const Tank&);
-  Tank& operator=(Tank&&) = default;
+  Tank& operator=(Tank&&);
   ~Tank() = default;
 
   void rotate_body(Rotation r);
@@ -58,13 +61,10 @@ class Tank {
   inline constexpr static float M_SPEED = 0.01f;
   void update_shot();
   void update_position();
-  void update_track_animations();
   void draw_shot(sf::RenderWindow& draw);
   void draw_tracks(sf::RenderWindow& draw);
 
   sf::Vector2f mPos;
-  // we do not want duplicates in deque
-  std::deque<std::tuple<sf::Vector2f, float, sf::Rect<int>>> mTracksAnimations{};
   float mCurrentSpeed = 0.0f;
   std::chrono::system_clock::time_point mShotStart;
   bool mDrawShot = false;
@@ -74,4 +74,5 @@ class Tank {
   TankPart mShot;
   TankPart mTracks;
   std::unique_ptr<Engine> mEngine;
+  std::unique_ptr<TracesHandler> mTracesHandler;
 };

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -37,7 +37,8 @@ class Tank {
  public:
   Tank() = delete;
   Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
-       sf::Texture& tracks, std::unique_ptr<Engine>&& engine);
+       sf::Texture& tracks, std::unique_ptr<Engine>&& engine, const int max_trace_age = 50,
+       const float trace_decay_rate = 0.1f);
   Tank(const Tank&);
   Tank(Tank&&);
   Tank& operator=(const Tank&);
@@ -72,7 +73,6 @@ class Tank {
   TankPart mBody;
   TankPart mTower;
   TankPart mShot;
-  TankPart mTracks;
   std::unique_ptr<Engine> mEngine;
   std::unique_ptr<TracesHandler> mTracesHandler;
 };

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -3,9 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <chrono>
-#include <deque>
 #include <memory>
-#include <tuple>
 
 #include "TextureStore.hpp"
 

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -8,7 +8,6 @@
 #include <tuple>
 
 #include "TextureStore.hpp"
-#include "TracesHandler.hpp"
 
 enum class Rotation { None, Clockwise, Counterclockwise };
 inline constexpr int shotAnimationDistance = 30;
@@ -19,7 +18,7 @@ class Engine;
 enum class Gear;
 class TankPart {
  public:
-  TankPart(sf::Texture& texture);
+  explicit TankPart(sf::Texture& texture);
 
   void rotate(const Rotation r);
   void set_rotation(const int angle);
@@ -43,7 +42,7 @@ class Tank {
   Tank(Tank&&);
   Tank& operator=(const Tank&);
   Tank& operator=(Tank&&);
-  ~Tank() = default;
+  ~Tank();
 
   void rotate_body(Rotation r);
   void rotate_tower(Rotation r);

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -3,9 +3,10 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <chrono>
-#include <memory>
 #include <deque>
+#include <memory>
 #include <tuple>
+
 #include "TextureStore.hpp"
 #include "TracesHandler.hpp"
 
@@ -36,8 +37,8 @@ class TankPart {
 class Tank {
  public:
   Tank() = delete;
-  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot, sf::Texture& tracks,
-       std::unique_ptr<Engine>&& engine);
+  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
+       sf::Texture& tracks, std::unique_ptr<Engine>&& engine);
   Tank(const Tank&);
   Tank(Tank&&);
   Tank& operator=(const Tank&);

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <SFML/System/Vector2.hpp>
 #include <chrono>
 #include <memory>
-
+#include <deque>
+#include <tuple>
 #include "TextureStore.hpp"
 
 enum class Rotation { None, Clockwise, Counterclockwise };
@@ -20,6 +22,7 @@ class TankPart {
   void set_rotation(const int angle);
   void draw(sf::RenderWindow& window, const float x, const float y);
   float get_rotation() const;
+  sf::Sprite& get_sprite();
   void update();
 
  private:
@@ -30,7 +33,7 @@ class TankPart {
 class Tank {
  public:
   Tank() = delete;
-  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
+  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot, sf::Texture& tracks,
        std::unique_ptr<Engine>&& engine);
   Tank(const Tank&);
   Tank(Tank&&) = default;
@@ -55,9 +58,13 @@ class Tank {
   inline constexpr static float M_SPEED = 0.01f;
   void update_shot();
   void update_position();
+  void update_track_animations();
   void draw_shot(sf::RenderWindow& draw);
+  void draw_tracks(sf::RenderWindow& draw);
 
   sf::Vector2f mPos;
+  // we do not want duplicates in deque
+  std::deque<std::tuple<sf::Vector2f, float, sf::Rect<int>>> mTracksAnimations{};
   float mCurrentSpeed = 0.0f;
   std::chrono::system_clock::time_point mShotStart;
   bool mDrawShot = false;
@@ -65,5 +72,6 @@ class Tank {
   TankPart mBody;
   TankPart mTower;
   TankPart mShot;
+  TankPart mTracks;
   std::unique_ptr<Engine> mEngine;
 };

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -14,6 +14,7 @@ inline constexpr int shotAnimationDistance = 30;
 inline constexpr std::chrono::milliseconds shotAnimationDuration = std::chrono::milliseconds(100);
 
 class TracesHandler;
+struct TracesHandlerConfig;
 class Engine;
 enum class Gear;
 class TankPart {
@@ -37,8 +38,8 @@ class Tank {
  public:
   Tank() = delete;
   Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
-       sf::Texture& tracks, std::unique_ptr<Engine>&& engine, const int max_trace_age = 50,
-       const float trace_decay_rate = 0.1f);
+       sf::Texture& tracks, std::unique_ptr<Engine>&& engine,
+       const TracesHandlerConfig& traces_handler_config);
   Tank(const Tank&);
   Tank(Tank&&);
   Tank& operator=(const Tank&);

--- a/src/TextureStore.cpp
+++ b/src/TextureStore.cpp
@@ -4,10 +4,10 @@
 
 #include "Files.hpp"
 
-sf::Texture& TextureStore::get_texture(const std::string& path) {
+sf::Texture& TextureStore::get_texture(const std::string& path, const sf::IntRect& area) {
   if (!mStore.contains(path)) {
     sf::Texture t;
-    if (!t.loadFromFile(files::default_size_path() + path)) {
+    if (!t.loadFromFile(files::default_size_path() + path, area)) {
       throw std::runtime_error(std::string("Texture ") + path + " not found");
     }
     mStore.insert(std::make_pair(path, std::move(t)));

--- a/src/TextureStore.hpp
+++ b/src/TextureStore.hpp
@@ -12,7 +12,7 @@ class TextureStore {
   TextureStore& operator=(TextureStore&&) = delete;
   ~TextureStore() = default;
 
-  sf::Texture& get_texture(const std::string& file);
+  sf::Texture& get_texture(const std::string& file, const sf::IntRect& = sf::IntRect{});
 
  private:
   std::unordered_map<std::string, sf::Texture> mStore;

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -1,0 +1,43 @@
+#include "Trace.hpp"
+
+Trace::Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
+             const float start_height)
+    : mTexture(tex) {
+  const float width = mTexture.getSize().x;
+  const auto origin = sf::Vector2f{width / 2, 0.f};
+  mTransform.translate(-origin).translate(pos);
+  mTransform.rotate(angle, origin);
+
+  mVertices[0].position = {0.f, 0.f};
+  mVertices[0].texCoords = {0.f, 0.f};
+
+  mVertices[1].position = {width, 0.f};
+  mVertices[1].texCoords = {width, 0.f};
+
+  mVertices[2].position = {width, start_height};
+  mVertices[2].texCoords = {width, start_height};
+
+  mVertices[3].position = {0.f, start_height};
+  mVertices[3].texCoords = {0.f, start_height};
+}
+
+void Trace::increase_height(const float amount) {
+  mVertices[2].position += sf::Vector2f{0.f, amount};
+  mVertices[2].texCoords += sf::Vector2f{0.f, amount};
+
+  mVertices[3].position += sf::Vector2f{0.f, amount};
+  mVertices[3].texCoords += sf::Vector2f{0.f, amount};
+}
+void Trace::decrease_height(const float amount) {
+  mVertices[0].position += sf::Vector2f{0.f, amount};
+  mVertices[0].texCoords += sf::Vector2f{0.f, amount};
+
+  mVertices[1].position += sf::Vector2f{0.f, amount};
+  mVertices[1].texCoords += sf::Vector2f{0.f, amount};
+}
+
+void Trace::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+  states.texture = &mTexture;
+  states.transform *= mTransform;
+  target.draw(mVertices, states);
+}

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -1,8 +1,9 @@
 #include "Trace.hpp"
+#include <cmath>
 
 Trace::Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
              const float start_height)
-    : mTexture(tex) {
+    : mTexture(tex), mRotation(angle) {
   const float width = mTexture.getSize().x;
   const auto origin = sf::Vector2f{width / 2, 0.f};
   mTransform.translate(-origin).translate(pos);
@@ -34,6 +35,14 @@ void Trace::decrease_height(const float amount) {
 
   mVertices[1].position += sf::Vector2f{0.f, amount};
   mVertices[1].texCoords += sf::Vector2f{0.f, amount};
+}
+
+float Trace::get_height() const {
+    return std::fabs((mVertices[0].position - mVertices[2].position).y);
+}
+
+float Trace::get_rotation() const {
+    return mRotation;
 }
 
 void Trace::draw(sf::RenderTarget& target, sf::RenderStates states) const {

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -1,4 +1,5 @@
 #include "Trace.hpp"
+
 #include <cmath>
 
 Trace::Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
@@ -38,12 +39,10 @@ void Trace::decrease_height(const float amount) {
 }
 
 float Trace::get_height() const {
-    return std::fabs((mVertices[0].position - mVertices[2].position).y);
+  return std::fabs((mVertices[0].position - mVertices[2].position).y);
 }
 
-float Trace::get_rotation() const {
-    return mRotation;
-}
+float Trace::get_rotation() const { return mRotation; }
 
 void Trace::draw(sf::RenderTarget& target, sf::RenderStates states) const {
   states.texture = &mTexture;

--- a/src/Trace.hpp
+++ b/src/Trace.hpp
@@ -1,0 +1,14 @@
+#include "SFML/Graphics.hpp"
+#include "SFML/Graphics/Drawable.hpp"
+
+class Trace : public sf::Drawable {
+  sf::Transform mTransform;
+  sf::VertexArray mVertices{sf::Quads, 4};
+  const sf::Texture& mTexture;
+
+  void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+ public:
+  Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle, const float start_height);
+  void increase_height(const float amount);
+  void decrease_height(const float amount);
+};

--- a/src/Trace.hpp
+++ b/src/Trace.hpp
@@ -1,14 +1,18 @@
 #include "SFML/Graphics.hpp"
-#include "SFML/Graphics/Drawable.hpp"
 
 class Trace : public sf::Drawable {
   sf::Transform mTransform;
   sf::VertexArray mVertices{sf::Quads, 4};
   const sf::Texture& mTexture;
+  float mRotation;
 
   void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
  public:
-  Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle, const float start_height);
+  Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
+        const float start_height);
   void increase_height(const float amount);
   void decrease_height(const float amount);
+  float get_height() const;
+  float get_rotation() const;
 };

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -8,12 +8,20 @@ void increaseSpriteHeight(sf::Sprite& sprite, int amount) {
   sprite.setTextureRect({rect.top, rect.left, rect.width, rect.height + amount});
 }
 
-TracesHandler::TracesHandler(sf::Texture& texture, const sf::Vector2f& pos)
-    : mTracks(texture), mStartingPosition(pos) {}
+sf::Vector2f getMiddleBotTransform(const sf::Sprite& sprite) {
+  const auto& [left, top, width, height] = sprite.getLocalBounds();
+  return sprite.getTransform().transformPoint({left + width / 2, top + height});
+}
 
-void TracesHandler::update(const sf::Vector2f& move) {
+TracesHandler::TracesHandler(sf::Texture& texture, sf::Sprite& tankSprite)
+    : mTracks(texture), mTankSprite(tankSprite), mLastTankPos(mTankSprite.getPosition()) {}
+
+void TracesHandler::update() {
+  const auto& move = mTankSprite.getPosition() - mLastTankPos;
+  mLastTankPos = mTankSprite.getPosition();
   sf::Sprite sprite(mTracks);
   const auto& rect = sprite.getTextureRect();
+  sprite.setOrigin(rect.width / 2, 0.f);
   const float moveAngle = get_angle(move);
   if (!mTraces.empty() && mTraces.back().getRotation() == moveAngle) {
     auto& trace = mTraces.back();
@@ -21,6 +29,7 @@ void TracesHandler::update(const sf::Vector2f& move) {
   } else {
     sprite.setTextureRect({rect.top, rect.left, rect.width, static_cast<int>(hypot(move))});
     sprite.setRotation(moveAngle);
+    sprite.setPosition(getMiddleBotTransform(mTankSprite));
     mTraces.push_back(sprite);
   }
 }

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -1,37 +1,99 @@
 #include "TracesHandler.hpp"
 
 #include "utility.hpp"
-constexpr int tracesCount = 1;
+constexpr int tracesCount = 70;
 
-void increaseSpriteHeight(sf::Sprite& sprite, int amount) {
+void setSpriteTextureHeight(sf::Sprite& sprite, int amount) {
   const auto& rect = sprite.getTextureRect();
-  sprite.setTextureRect({rect.top, rect.left, rect.width, rect.height + amount});
+  sprite.setTextureRect({rect.left, rect.top, rect.width, amount});
 }
 
-sf::Vector2f getMiddleBotTransform(const sf::Sprite& sprite) {
+void increaseSpriteHeight(sf::Sprite& sprite, const int amount) {
+  const auto& rect = sprite.getTextureRect();
+  setSpriteTextureHeight(sprite, rect.height + amount);
+}
+
+sf::Vector2f getMiddleTopTransform(const sf::Sprite& sprite, const float additional_value = 0.f) {
   const auto& [left, top, width, height] = sprite.getLocalBounds();
-  return sprite.getTransform().transformPoint({left + width / 2, top + height});
+  return sprite.getTransform().transformPoint({width / 2, 0.f + additional_value});
 }
 
-TracesHandler::TracesHandler(sf::Texture& texture, sf::Sprite& tankSprite)
-    : mTracks(texture), mTankSprite(tankSprite), mLastTankPos(mTankSprite.getPosition()) {}
+sf::Vector2f getMiddleBotTransform(const sf::Sprite& sprite, const float additional_value = 0.f) {
+  const auto& [left, top, width, height] = sprite.getLocalBounds();
+  return sprite.getTransform().transformPoint({width / 2, height + additional_value});
+}
+
+bool TracesHandler::is_move_zero() const {
+  return equal(mTankSprite.getPosition(), mLastTankPos);
+}
+
+TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tankSprite, const sf::Vector2f& startingPosition)
+    : mTracksTexture(texture), mTankSprite(tankSprite), mLastTankPos(startingPosition), mMaxTextureHeight(mTracksTexture.getSize().y - 4) {
+    }
+
+
+int TracesHandler::get_texture_height(const float move_distance) {
+  mTextureHeight += move_distance;
+  int return_value = static_cast<int>(mTextureHeight);
+  mTextureHeight -= return_value;
+  return return_value;
+}
+
+bool TracesHandler::is_moving_forward(const sf::Vector2f& move) const {
+  return equal(get_angle(move), mTankSprite.getRotation()); 
+}
 
 void TracesHandler::update() {
+  if (is_move_zero()) {
+    return;
+  }
+  // print_point(move);
+  // if (mTraces.size() > tracesCount) {
+  //   mTraces.pop_front();
+  // }
   const auto& move = mTankSprite.getPosition() - mLastTankPos;
   mLastTankPos = mTankSprite.getPosition();
-  sf::Sprite sprite(mTracks);
+  const float moveDistance = hypot(move);
+  int texture_height = get_texture_height(moveDistance);
+  sf::Sprite sprite(mTracksTexture);
   const auto& rect = sprite.getTextureRect();
-  sprite.setOrigin(rect.width / 2, 0.f);
-  const float moveAngle = get_angle(move);
-  if (!mTraces.empty() && mTraces.back().getRotation() == moveAngle) {
-    auto& trace = mTraces.back();
-    increaseSpriteHeight(trace, hypot(move));
-  } else {
-    sprite.setTextureRect({rect.top, rect.left, rect.width, static_cast<int>(hypot(move))});
-    sprite.setRotation(moveAngle);
-    sprite.setPosition(getMiddleBotTransform(mTankSprite));
-    mTraces.push_back(sprite);
+  sprite.setOrigin(rect.width / 2, 0);
+  float moveAngle = get_angle(move) - 180.f;
+  if (moveAngle < 0.f) {
+    moveAngle = 360.f + moveAngle;
   }
+  sprite.setRotation(moveAngle);
+  // this depends whether tank moves forward or backward
+  if (is_moving_forward(move)) {
+    sprite.setPosition(getMiddleBotTransform(mTankSprite, moveDistance));
+  } else {
+    std::cout << "is not moving forward\n";
+    sprite.setPosition(getMiddleTopTransform(mTankSprite, -moveDistance));
+  }
+  setSpriteTextureHeight(sprite, texture_height);
+  //default; should be done if none of the conditions is true!
+  //the same angle; increase the sprite height accordingly
+  if (!mTraces.empty() && equal(mTraces.back().getRotation(), moveAngle)) {
+    // std::cout << "the same angle\n";
+    sf::Sprite& trace = mTraces.back();
+    const auto traceRect = trace.getTextureRect();
+    // if current move distance would overrun max texture height
+    if (texture_height + traceRect.height > mMaxTextureHeight) {
+      int newTrackHeight = texture_height - (mMaxTextureHeight - traceRect.height);
+      setSpriteTextureHeight(trace, mMaxTextureHeight);
+      setSpriteTextureHeight(sprite, newTrackHeight);
+      sprite.setPosition(getMiddleBotTransform(mTankSprite, newTrackHeight));
+    } else {
+      increaseSpriteHeight(trace, texture_height);
+        DISTANCE_TRAVELLED += moveDistance;
+        TOTAL_TEXTURE_HEIGHT += texture_height;
+        // std::cout << "total distance: " << DISTANCE_TRAVELLED << "\n";
+        // std::cout << "texture height: " << TOTAL_TEXTURE_HEIGHT << "\n";
+        // std::cout << "----------------------------------\n";
+      return;
+    }
+  }
+  mTraces.push_back(sprite);
 }
 
-const std::deque<sf::Sprite>& TracesHandler::getTraces() { return mTraces; }
+const std::deque<sf::Sprite>& TracesHandler::getTraces() const { return mTraces; }

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -1,15 +1,28 @@
 #include "TracesHandler.hpp"
+
 #include "utility.hpp"
 constexpr int tracesCount = 1;
 
-TracesHandler::TracesHandler(sf::Texture& texture, const sf::Vector2f& pos) : mTracks(texture), mStartingPosition(pos) {}
+void increaseSpriteHeight(sf::Sprite& sprite, int amount) {
+  const auto& rect = sprite.getTextureRect();
+  sprite.setTextureRect({rect.top, rect.left, rect.width, rect.height + amount});
+}
+
+TracesHandler::TracesHandler(sf::Texture& texture, const sf::Vector2f& pos)
+    : mTracks(texture), mStartingPosition(pos) {}
 
 void TracesHandler::update(const sf::Vector2f& move) {
-    sf::Sprite sprite(mTracks);
-    auto rect = sprite.getTextureRect();
-    sprite.setTextureRect({rect.top, rect.left, rect.width, hypot(move)});
-    sprite.setRotation(get_angle(move));
+  sf::Sprite sprite(mTracks);
+  const auto& rect = sprite.getTextureRect();
+  const float moveAngle = get_angle(move);
+  if (!mTraces.empty() && mTraces.back().getRotation() == moveAngle) {
+    auto& trace = mTraces.back();
+    increaseSpriteHeight(trace, hypot(move));
+  } else {
+    sprite.setTextureRect({rect.top, rect.left, rect.width, static_cast<int>(hypot(move))});
+    sprite.setRotation(moveAngle);
     mTraces.push_back(sprite);
+  }
 }
 
 const std::deque<sf::Sprite>& TracesHandler::getTraces() { return mTraces; }

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -1,0 +1,15 @@
+#include "TracesHandler.hpp"
+#include "utility.hpp"
+constexpr int tracesCount = 1;
+
+TracesHandler::TracesHandler(sf::Texture& texture, const sf::Vector2f& pos) : mTracks(texture), mStartingPosition(pos) {}
+
+void TracesHandler::update(const sf::Vector2f& move) {
+    sf::Sprite sprite(mTracks);
+    auto rect = sprite.getTextureRect();
+    sprite.setTextureRect({rect.top, rect.left, rect.width, hypot(move)});
+    sprite.setRotation(get_angle(move));
+    mTraces.push_back(sprite);
+}
+
+const std::deque<sf::Sprite>& TracesHandler::getTraces() { return mTraces; }

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -23,6 +23,8 @@ sf::Vector2f getMiddleBotTransform(const sf::Sprite& sprite, const float additio
   return sprite.getTransform().transformPoint({width / 2, height + additional_value});
 }
 
+float TracesHandler::get_max_texture_height() const { return mMaxTextureHeight; }
+
 bool TracesHandler::is_move_zero() const { return equal(mTankSprite.getPosition(), mLastTankPos); }
 
 TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tankSprite,
@@ -48,10 +50,6 @@ void TracesHandler::update() {
     mLastTankPos = mTankSprite.getPosition();
     return;
   }
-  // print_point(move);
-  // if (mTraces.size() > tracesCount) {
-  //   mTraces.pop_front();
-  // }
   const auto& move = mTankSprite.getPosition() - mLastTankPos;
   mLastTankPos = mTankSprite.getPosition();
   const float moveDistance = hypot(move);
@@ -64,24 +62,15 @@ void TracesHandler::update() {
     moveAngle = 360.f + moveAngle;
   }
   sprite.setRotation(moveAngle);
-  // this depends whether tank moves forward or backward
-  std::cout << "body rotation: " << mTankSprite.getRotation() << "\n";
-  std::cout << "move angle: " << get_angle(move) << "\n";
   if (is_moving_forward(move)) {
     sprite.setPosition(getMiddleBotTransform(mTankSprite, moveDistance));
   } else {
-    std::cout << "is not moving forward\n";
     sprite.setPosition(getMiddleTopTransform(mTankSprite, -moveDistance));
   }
-  std::cout << "-------------------\n";
   setSpriteTextureHeight(sprite, texture_height);
-  // default; should be done if none of the conditions is true!
-  // the same angle; increase the sprite height accordingly
   if (!mTraces.empty() && equal(mTraces.back().getRotation(), moveAngle, 1.0)) {
-    // std::cout << "the same angle\n";
     sf::Sprite& trace = mTraces.back();
     const auto traceRect = trace.getTextureRect();
-    // if current move distance would overrun max texture height
     if (texture_height + traceRect.height > mMaxTextureHeight) {
       int newTrackHeight = texture_height - (mMaxTextureHeight - traceRect.height);
       setSpriteTextureHeight(trace, mMaxTextureHeight);
@@ -95,9 +84,6 @@ void TracesHandler::update() {
       increaseSpriteHeight(trace, texture_height);
       DISTANCE_TRAVELLED += moveDistance;
       TOTAL_TEXTURE_HEIGHT += texture_height;
-      // std::cout << "total distance: " << DISTANCE_TRAVELLED << "\n";
-      // std::cout << "texture height: " << TOTAL_TEXTURE_HEIGHT << "\n";
-      // std::cout << "----------------------------------\n";
       return;
     }
   }

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -2,10 +2,6 @@
 
 #include "utility.hpp"
 
-constexpr short AGE_THRESHOLD = 70;
-constexpr float TRACE_DECAY_RATE = 0.1f;
-
-
 sf::Vector2f get_middle_top_transform(const sf::Sprite& sprite,
                                       const float additional_value = 0.f) {
   const auto& [left, top, width, height] = sprite.getLocalBounds();
@@ -19,16 +15,25 @@ sf::Vector2f get_middle_bot_transform(const sf::Sprite& sprite,
       {left + width / 2.f, top + height + additional_value});
 }
 
-TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tankSprite,
-                             const sf::Vector2f& startingPosition)
+TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tank_sprite,
+                             const sf::Vector2f& start_pos, const int max_trace_age,
+                             const float decay_rate)
     : mTracksTexture(texture),
-      mTankSprite(tankSprite),
-      mLastTankPos(startingPosition),
-      mMaxTextureHeight(mTracksTexture.getSize().y) {}
+      mTankSprite(tank_sprite),
+      mLastTankPos(start_pos),
+      mMaxTextureHeight(mTracksTexture.getSize().y),
+      mMaxTraceAge(max_trace_age),
+      mTraceDecayRate(decay_rate) {}
 
 float TracesHandler::get_max_texture_height() const { return mMaxTextureHeight; }
 
 std::deque<Trace> TracesHandler::get_traces() const { return mTraces; }
+
+const sf::Texture& TracesHandler::get_trace_texture() const { return mTracksTexture; }
+
+int TracesHandler::get_max_trace_age() const { return mMaxTraceAge; }
+
+float TracesHandler::get_trace_decay_rate() const { return mTraceDecayRate; }
 
 void TracesHandler::update() {
   const auto& move = mTankSprite.getPosition() - mLastTankPos;
@@ -47,7 +52,7 @@ void TracesHandler::update() {
 
 void TracesHandler::update_traces_age() {
   for (short& age : mTracesAge) {
-    if (age < 70) {
+    if (age < mMaxTraceAge) {
       age++;
     }
   }
@@ -57,10 +62,10 @@ void TracesHandler::decay_traces() {
   if (mTracesAge.size() <= 0) {
     return;
   }
-  if (mTracesAge.front() >= AGE_THRESHOLD) {
+  if (mTracesAge.front() >= mMaxTraceAge) {
     const float trace_height = mTraces.front().get_height();
-    const float decrease_by = std::min(TRACE_DECAY_RATE * mMaxTextureHeight, trace_height);
-    if (decrease_by < TRACE_DECAY_RATE * mMaxTextureHeight) {
+    const float decrease_by = std::min(mTraceDecayRate * mMaxTextureHeight, trace_height);
+    if (decrease_by < mTraceDecayRate * mMaxTextureHeight) {
       remove_trace();
       return;
     }

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -6,10 +6,11 @@
 class TracesHandler {
   sf::Texture& mTracks;
   std::deque<sf::Sprite> mTraces{};
-  sf::Vector2f mStartingPosition{};
+  sf::Sprite& mTankSprite;
+  sf::Vector2f mLastTankPos{};
 
  public:
-  TracesHandler(sf::Texture& tracks, const sf::Vector2f& pos);
-  void update(const sf::Vector2f& move);
+  TracesHandler(sf::Texture& tracks, sf::Sprite& tankSprite);
+  void update();
   const std::deque<sf::Sprite>& getTraces();
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -2,15 +2,28 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <deque>
+// #include <functional>
 
 class TracesHandler {
-  sf::Texture& mTracks;
-  std::deque<sf::Sprite> mTraces{};
+  const sf::Texture& mTracksTexture;
   sf::Sprite& mTankSprite;
+  std::deque<sf::Sprite> mTraces{};
   sf::Vector2f mLastTankPos{};
+  float mMaxTextureHeight{};
+  float DISTANCE_TRAVELLED{};
+  float mTextureHeight{};
+  float TOTAL_TEXTURE_HEIGHT{};
 
+  int get_texture_height(const float);
+  bool is_move_zero() const;
+  bool is_moving_forward(const sf::Vector2f&) const;
  public:
-  TracesHandler(sf::Texture& tracks, sf::Sprite& tankSprite);
+  TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite, const sf::Vector2f& startingPosition);
+  TracesHandler(const TracesHandler&) = delete;
+  TracesHandler(TracesHandler&&) = delete;
+  TracesHandler& operator=(const TracesHandler&) = delete;
+  TracesHandler& operator=(TracesHandler&&) = delete;
+  ~TracesHandler() = default;
   void update();
-  const std::deque<sf::Sprite>& getTraces();
+  const std::deque<sf::Sprite>& getTraces() const;
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -5,6 +5,11 @@
 
 #include "Trace.hpp"
 
+struct TracesHandlerConfig {
+  int mMaxTraceAge;
+  float mDecayRate;
+};
+
 class TracesHandler {
   const sf::Texture& mTracksTexture;
   sf::Sprite& mTankSprite;
@@ -12,8 +17,7 @@ class TracesHandler {
   std::deque<short> mTracesAge{};
   sf::Vector2f mLastTankPos{};
   int mMaxTextureHeight{};
-  int mMaxTraceAge{};
-  float mTraceDecayRate{};
+  TracesHandlerConfig mConfig{};
 
   void update_traces_age();
   void decay_traces();
@@ -27,16 +31,16 @@ class TracesHandler {
  public:
   TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite, const sf::Vector2f& start_pos,
                 const int max_trace_age, const float decay_rate);
+  TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite, const sf::Vector2f& start_pos,
+                const TracesHandlerConfig& config);
   TracesHandler(const TracesHandler&) = delete;
   TracesHandler(TracesHandler&&) = delete;
   TracesHandler& operator=(const TracesHandler&) = delete;
   TracesHandler& operator=(TracesHandler&&) = delete;
   ~TracesHandler() = default;
 
-  std::deque<Trace> get_traces() const;
-  float get_max_texture_height() const;
+  const std::deque<Trace>& get_traces() const;
   const sf::Texture& get_trace_texture() const;
-  int get_max_trace_age() const;
-  float get_trace_decay_rate() const;
+  TracesHandlerConfig get_config() const;
   void update();
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <deque>
+
+class TracesHandler {
+  sf::Texture& mTracks;
+  std::deque<sf::Sprite> mTraces{};
+  sf::Vector2f mStartingPosition{};
+
+ public:
+  TracesHandler(sf::Texture& tracks, const sf::Vector2f& pos);
+  void update(const sf::Vector2f& move);
+  const std::deque<sf::Sprite>& getTraces();
+};

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -17,8 +17,10 @@ class TracesHandler {
   int get_texture_height(const float);
   bool is_move_zero() const;
   bool is_moving_forward(const sf::Vector2f&) const;
+
  public:
-  TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite, const sf::Vector2f& startingPosition);
+  TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite,
+                const sf::Vector2f& startingPosition);
   TracesHandler(const TracesHandler&) = delete;
   TracesHandler(TracesHandler&&) = delete;
   TracesHandler& operator=(const TracesHandler&) = delete;
@@ -26,4 +28,5 @@ class TracesHandler {
   ~TracesHandler() = default;
   void update();
   const std::deque<sf::Sprite>& getTraces() const;
+  float get_max_texture_height() const;
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -3,22 +3,24 @@
 #include <SFML/System/Vector2.hpp>
 #include <deque>
 
+#include "Trace.hpp"
+
 class TracesHandler {
   const sf::Texture& mTracksTexture;
   sf::Sprite& mTankSprite;
-  std::deque<sf::Sprite> mTraces{};
+  std::deque<Trace> mTraces{};
+  std::deque<short> mTracesAge{};
   sf::Vector2f mLastTankPos{};
-  float mMaxTextureHeight{};
-  float mTextureHeight{};
+  int mMaxTextureHeight{};
 
-  bool is_move_zero() const;
-  int get_current_move_texture_height(const float);
+  void update_traces_age();
+  void decay_traces();
+  void add_trace(const Trace& sp);
+  void remove_trace();
   bool is_move_angle_changed(const sf::Vector2f& move) const;
-  float get_opposite_angle(const sf::Vector2f& move) const;
-  sf::Sprite get_sprite(const sf::Vector2f& move, const int sprite_height) const;
+  float get_opposite_angle(const float angle) const;
+  Trace make_trace(const sf::Vector2f& move) const;
   bool is_moving_forward(const sf::Vector2f&) const;
-  bool new_height_exceeds_max_height(const int sprite_height) const;
-  int get_new_trace_height(const int sprite_height) const;
 
  public:
   TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite,
@@ -29,7 +31,7 @@ class TracesHandler {
   TracesHandler& operator=(TracesHandler&&) = delete;
   ~TracesHandler() = default;
 
-  const std::deque<sf::Sprite>& get_traces() const;
+  std::deque<Trace> get_traces() const;
   float get_max_texture_height() const;
   void update();
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -12,6 +12,8 @@ class TracesHandler {
   std::deque<short> mTracesAge{};
   sf::Vector2f mLastTankPos{};
   int mMaxTextureHeight{};
+  int mMaxTraceAge{};
+  float mTraceDecayRate{};
 
   void update_traces_age();
   void decay_traces();
@@ -23,8 +25,8 @@ class TracesHandler {
   bool is_moving_forward(const sf::Vector2f&) const;
 
  public:
-  TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite,
-                const sf::Vector2f& startingPosition);
+  TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite, const sf::Vector2f& start_pos,
+                const int max_trace_age, const float decay_rate);
   TracesHandler(const TracesHandler&) = delete;
   TracesHandler(TracesHandler&&) = delete;
   TracesHandler& operator=(const TracesHandler&) = delete;
@@ -33,5 +35,8 @@ class TracesHandler {
 
   std::deque<Trace> get_traces() const;
   float get_max_texture_height() const;
+  const sf::Texture& get_trace_texture() const;
+  int get_max_trace_age() const;
+  float get_trace_decay_rate() const;
   void update();
 };

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -2,7 +2,6 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <deque>
-// #include <functional>
 
 class TracesHandler {
   const sf::Texture& mTracksTexture;
@@ -10,13 +9,16 @@ class TracesHandler {
   std::deque<sf::Sprite> mTraces{};
   sf::Vector2f mLastTankPos{};
   float mMaxTextureHeight{};
-  float DISTANCE_TRAVELLED{};
   float mTextureHeight{};
-  float TOTAL_TEXTURE_HEIGHT{};
 
-  int get_texture_height(const float);
   bool is_move_zero() const;
+  int get_current_move_texture_height(const float);
+  bool is_move_angle_changed(const sf::Vector2f& move) const;
+  float get_opposite_angle(const sf::Vector2f& move) const;
+  sf::Sprite get_sprite(const sf::Vector2f& move, const int sprite_height) const;
   bool is_moving_forward(const sf::Vector2f&) const;
+  bool new_height_exceeds_max_height(const int sprite_height) const;
+  int get_new_trace_height(const int sprite_height) const;
 
  public:
   TracesHandler(const sf::Texture& tracks, sf::Sprite& tankSprite,
@@ -26,7 +28,8 @@ class TracesHandler {
   TracesHandler& operator=(const TracesHandler&) = delete;
   TracesHandler& operator=(TracesHandler&&) = delete;
   ~TracesHandler() = default;
-  void update();
-  const std::deque<sf::Sprite>& getTraces() const;
+
+  const std::deque<sf::Sprite>& get_traces() const;
   float get_max_texture_height() const;
+  void update();
 };

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -1,4 +1,12 @@
 #pragma once
+#include <SFML/System/Vector2.hpp>
+#include <cmath>
+
 #include "Size.hpp"
 
 constexpr inline float to_radians(float degrees) { return pi / 180.f * degrees; }
+inline sf::Vector2f abs(const sf::Vector2f& vec) { return {std::abs(vec.x), std::abs(vec.y)}; }
+inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
+inline sf::Vector2f get_pos(const sf::Vector2f& start, float move_distance, float move_angle) {
+    
+}

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -9,6 +9,7 @@ constexpr inline double to_radians(double degrees) { return pi / 180.f * degrees
 constexpr inline double to_degrees(double radians) { return radians / pi * 180; }
 inline sf::Vector2f fabs(const sf::Vector2f& vec) { return {std::fabs(vec.x), std::fabs(vec.y)}; }
 inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
+
 inline bool equal(float lhs, float rhs, float precision = 0.001f) {
   return std::fabs(lhs - rhs) < precision;
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -1,12 +1,36 @@
 #pragma once
 #include <SFML/System/Vector2.hpp>
 #include <cmath>
-
+#include <iostream>
 #include "Size.hpp"
 
-constexpr inline float to_radians(float degrees) { return pi / 180.f * degrees; }
+constexpr inline double to_radians(double degrees) { return pi / 180.f * degrees; }
+constexpr inline double to_degrees(double radians) { return radians / pi * 180; }
 inline sf::Vector2f abs(const sf::Vector2f& vec) { return {std::abs(vec.x), std::abs(vec.y)}; }
 inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
-inline sf::Vector2f get_pos(const sf::Vector2f& start, float move_distance, float move_angle) {
-    
+inline bool equal(float lhs, float rhs, float precision = 0.0001f) {
+  return abs(lhs - rhs) < precision;
 }
+
+inline void printRect(const auto& rect) {
+  const auto& [x, y, width, height] = rect;
+  std::cout << "(x, y): (" << x << ", " << y << ") - (w x h): (" << width << " x " << height
+            << ")\n";
+}
+
+inline void print_point(const auto& point) {
+  const auto& [x, y] = point;
+  std::cout << "(x, y): (" << x << ", " << y << ")\n";
+}
+
+inline float get_angle(const sf::Vector2f& vec) {
+  if (equal(vec.x, 0.f) && equal(vec.y, 0.f)) {
+    return 0.f;
+  }
+  auto degrees = to_degrees(atan2(vec.y, vec.x)) + 90;
+  if (degrees < 0) {
+    return 360 + degrees;
+  }
+  return degrees;
+}
+

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -12,6 +12,10 @@ inline bool equal(float lhs, float rhs, float precision = 0.0001f) {
   return abs(lhs - rhs) < precision;
 }
 
+inline bool equal(const sf::Vector2f& lhs, const sf::Vector2f& rhs, float precision = 0.0001f) {
+  return equal(lhs.x, rhs.x, precision) && equal(lhs.y, rhs.y, precision);
+}
+
 inline void printRect(const auto& rect) {
   const auto& [x, y, width, height] = rect;
   std::cout << "(x, y): (" << x << ", " << y << ") - (w x h): (" << width << " x " << height

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -6,13 +6,13 @@
 
 constexpr inline double to_radians(double degrees) { return pi / 180.f * degrees; }
 constexpr inline double to_degrees(double radians) { return radians / pi * 180; }
-inline sf::Vector2f abs(const sf::Vector2f& vec) { return {std::abs(vec.x), std::abs(vec.y)}; }
+inline sf::Vector2f fabs(const sf::Vector2f& vec) { return {std::fabs(vec.x), std::fabs(vec.y)}; }
 inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
-inline bool equal(float lhs, float rhs, float precision = 0.0001f) {
-  return abs(lhs - rhs) < precision;
+inline bool equal(float lhs, float rhs, float precision = 0.001f) {
+  return std::fabs(lhs - rhs) < precision;
 }
 
-inline bool equal(const sf::Vector2f& lhs, const sf::Vector2f& rhs, float precision = 0.0001f) {
+inline bool equal(const sf::Vector2f& lhs, const sf::Vector2f& rhs, float precision = 0.001f) {
   return equal(lhs.x, rhs.x, precision) && equal(lhs.y, rhs.y, precision);
 }
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -2,6 +2,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <cmath>
 #include <iostream>
+
 #include "Size.hpp"
 
 constexpr inline double to_radians(double degrees) { return pi / 180.f * degrees; }
@@ -37,4 +38,3 @@ inline float get_angle(const sf::Vector2f& vec) {
   }
   return degrees;
 }
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(run_tests
   SquareRootEngineTests.cpp
   TestUtility.cpp
   UtilityTests.cpp
+  TracesHandlerTests.cpp
 )
 
 target_include_directories(run_tests PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(run_tests
   TextureStoreTests.cpp
   SquareRootEngineTests.cpp
   TestUtility.cpp
+  UtilityTests.cpp
 )
 
 target_include_directories(run_tests PRIVATE

--- a/test/SquareRootEngineTests.cpp
+++ b/test/SquareRootEngineTests.cpp
@@ -14,7 +14,7 @@ constexpr auto getSpeedDelta(auto speed_before, auto speed_after) {
 struct SquareRootEngineTest : ::testing::Test {
   double mPrecision{0.0001};
   int mStepCount{1};
-  int mMaxSpeed{5};
+  float mMaxSpeed{5};
   float mSpeed{1.f};
   float mZero{0.f};
   float mAngle{0.f};

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -6,6 +6,7 @@
 #include "SquareRootEngine.hpp"
 #include "Tank.hpp"
 #include "TestUtility.hpp"
+#include "TracesHandler.hpp"
 #include "gmock/gmock.h"
 #include "utility.hpp"
 
@@ -32,11 +33,13 @@ struct TankTest : ::testing::Test {
   int mAngle{90};
 
   Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
-    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine));
+    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine),
+                TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f});
   }
 
   Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
-    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine));
+    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine),
+                TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f});
   }
 };
 

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -27,6 +27,7 @@ struct TankTest : ::testing::Test {
   sf::Texture mBody{create_dummy_texture()};
   sf::Texture mTower{create_dummy_texture()};
   sf::Texture mShot{create_dummy_texture()};
+  sf::Texture mTracks{create_dummy_texture()};
   std::unique_ptr<testing::NiceMock<EngineMock>> mEngine{
       std::make_unique<testing::NiceMock<EngineMock>>()};
   std::shared_ptr<testing::NiceMock<EngineMock>> mEngineNiceMock{
@@ -37,11 +38,11 @@ struct TankTest : ::testing::Test {
   int mAngle{90};
 
   Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
-    return Tank(0, 0, mBody, mTower, mShot, std::move(engine));
+    return Tank(0, 0, mBody, mTower, mShot, mTracks, std::move(engine));
   }
 
   Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
-    return Tank(0, 0, mBody, mTower, mShot, std::move(engine));
+    return Tank(0, 0, mBody, mTower, mShot, mTracks, std::move(engine));
   }
 };
 

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -9,8 +9,6 @@
 #include "gmock/gmock.h"
 #include "utility.hpp"
 
-
-
 struct EngineMock : Engine {
   MOCK_METHOD(void, set_gear, (Gear), (override));
   MOCK_METHOD(float, get_current_speed, (), (const, override));

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -9,11 +9,7 @@
 #include "gmock/gmock.h"
 #include "utility.hpp"
 
-static sf::Texture create_dummy_texture() {
-  sf::Texture dummy;
-  dummy.create(5, 5);
-  return dummy;
-}
+
 
 struct EngineMock : Engine {
   MOCK_METHOD(void, set_gear, (Gear), (override));
@@ -24,10 +20,10 @@ struct EngineMock : Engine {
 };
 
 struct TankTest : ::testing::Test {
-  sf::Texture mBody{create_dummy_texture()};
-  sf::Texture mTower{create_dummy_texture()};
-  sf::Texture mShot{create_dummy_texture()};
-  sf::Texture mTracks{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mBody{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mTower{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mShot{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mTracks{create_dummy_texture()};
   std::unique_ptr<testing::NiceMock<EngineMock>> mEngine{
       std::make_unique<testing::NiceMock<EngineMock>>()};
   std::shared_ptr<testing::NiceMock<EngineMock>> mEngineNiceMock{
@@ -38,11 +34,11 @@ struct TankTest : ::testing::Test {
   int mAngle{90};
 
   Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
-    return Tank(0, 0, mBody, mTower, mShot, mTracks, std::move(engine));
+    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine));
   }
 
   Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
-    return Tank(0, 0, mBody, mTower, mShot, mTracks, std::move(engine));
+    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine));
   }
 };
 

--- a/test/TestUtility.cpp
+++ b/test/TestUtility.cpp
@@ -9,7 +9,7 @@ void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs) {
   EXPECT_NEAR(y1, y2, 0.0001);
 }
 
-std::unique_ptr<sf::Texture> create_dummy_texture(uint width, uint height) {
+std::unique_ptr<sf::Texture> create_dummy_texture(unsigned int width, unsigned int height) {
   auto dummy = std::make_unique<sf::Texture>();
   dummy->create(width, height);
   return dummy;

--- a/test/TestUtility.cpp
+++ b/test/TestUtility.cpp
@@ -8,3 +8,9 @@ void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs) {
   EXPECT_NEAR(x1, x2, 0.0001);
   EXPECT_NEAR(y1, y2, 0.0001);
 }
+
+std::unique_ptr<sf::Texture> create_dummy_texture(uint width, uint height) {
+  auto dummy = std::make_unique<sf::Texture>();
+  dummy->create(width, height);
+  return dummy;
+}

--- a/test/TestUtility.hpp
+++ b/test/TestUtility.hpp
@@ -1,11 +1,12 @@
 #pragma once
 #include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Texture.hpp>
 #include <range/v3/view/iota.hpp>
+#include <memory>
 
-#include "Engine.hpp"
-#include "Tank.hpp"
-
+inline constexpr double precision{0.0001}; 
 void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs);
+std::unique_ptr<sf::Texture> create_dummy_texture(uint = 5, uint = 5);
 
 template <typename T>
 concept Updatable = requires(T a) {

--- a/test/TestUtility.hpp
+++ b/test/TestUtility.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include <SFML/System/Vector2.hpp>
 #include <SFML/Graphics/Texture.hpp>
-#include <range/v3/view/iota.hpp>
+#include <SFML/System/Vector2.hpp>
 #include <memory>
+#include <range/v3/view/iota.hpp>
 
-inline constexpr double precision{0.0001}; 
+inline constexpr double precision{0.0001};
 void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs);
 std::unique_ptr<sf::Texture> create_dummy_texture(uint = 5, uint = 5);
 

--- a/test/TestUtility.hpp
+++ b/test/TestUtility.hpp
@@ -6,7 +6,7 @@
 
 inline constexpr double precision{0.0001};
 void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs);
-std::unique_ptr<sf::Texture> create_dummy_texture(uint = 5, uint = 5);
+std::unique_ptr<sf::Texture> create_dummy_texture(unsigned int = 5, unsigned int = 5);
 
 template <typename T>
 concept Updatable = requires(T a) {

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -41,7 +41,7 @@ TEST_P(TracesHandlerRotationTest, GivenMove_ThenTraceShouldHaveOppositeRotation)
 
   mTankSprite.move(move);
   mHandler.update();
-  const auto& actual_traces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.get_traces();
 
   ASSERT_EQ(1, actual_traces.size());
   EXPECT_NEAR(expected_rotation, get_trace_rotation(actual_traces, 0), precision);
@@ -63,7 +63,7 @@ TEST_P(TracesHandlerTextureHeightTest, GivenMove_ThenTraceShouldHaveHeightEqualT
 
   mTankSprite.move(move);
   mHandler.update();
-  const auto& actual_traces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.get_traces();
 
   ASSERT_EQ(1, actual_traces.size());
   EXPECT_NEAR(expected_height, get_trace_height(actual_traces, 0), precision);
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_CASE_P(TextureHeightTestsWithManyValues, TracesHandlerTextureHe
 class TracesHandlerTest : public BaseFixture, public ::testing::Test {};
 
 TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
-  auto actual_traces = mHandler.getTraces();
+  auto actual_traces = mHandler.get_traces();
 
   EXPECT_TRUE(actual_traces.empty());
 }
@@ -95,7 +95,7 @@ TEST_F(TracesHandlerTest,
   mTankSprite.move(move2);
   mHandler.update();
 
-  const auto& actual_traces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.get_traces();
 
   ASSERT_EQ(1, actual_traces.size());
   EXPECT_EQ(expected_height, get_trace_height(actual_traces, 0));
@@ -117,7 +117,7 @@ TEST_F(TracesHandlerTest,
   mTankSprite.move(move3);
   mHandler.update();
 
-  const auto& actual_traces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.get_traces();
 
   ASSERT_EQ(3, actual_traces.size());
   EXPECT_EQ(expected_height1, get_trace_height(actual_traces, 0));
@@ -138,7 +138,7 @@ TEST_F(TracesHandlerTest,
   mTankSprite.move(move2);
   mHandler.update();
 
-  const auto& actual_traces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.get_traces();
 
   ASSERT_EQ(2, actual_traces.size());
   EXPECT_EQ(expected_height1, get_trace_height(actual_traces, 0));

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -4,100 +4,143 @@
 #include "TracesHandler.hpp"
 #include "utility.hpp"
 
-sf::Sprite setUpSprite(sf::Texture& tex) {
+sf::Sprite set_up_sprite(sf::Texture& tex, const sf::Vector2f& startPosition) {
   sf::Sprite sprite(tex);
   const auto& [left, top, width, height] = sprite.getLocalBounds();
   sprite.setOrigin(width / 2, height / 2);
-  sprite.setPosition({0.f, 0.f});
+  sprite.setPosition(startPosition);
   sprite.setRotation(0.f);
   return sprite;
 }
 
-void moveSprite(sf::Sprite& sprite, const sf::Vector2f& move) {
-  sprite.move(move);
-  sprite.setRotation(get_angle(move));
+float get_trace_rotation(const std::deque<sf::Sprite>& traces, int idx) {
+  return traces[idx].getRotation();
 }
 
-class TracesHandlerTest : public ::testing::Test {
+int get_trace_height(const std::deque<sf::Sprite>& traces, int idx) {
+  return traces[idx].getTextureRect().height;
+}
+
+class BaseFixture {
  protected:
   uint mWidth{10};
   uint mHeight{20};
   sf::Vector2f mStartPosition{0.f, 0.f};
   std::unique_ptr<sf::Texture> mTexture{create_dummy_texture(mWidth, mHeight)};
-  sf::Sprite mTankSprite{setUpSprite(*mTexture)};
-  TracesHandler mHandler{*mTexture, mTankSprite};
+  sf::Sprite mTankSprite{set_up_sprite(*mTexture, mStartPosition)};
+  TracesHandler mHandler{*mTexture, mTankSprite, mStartPosition};
 };
 
-TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
-  auto actualTraces = mHandler.getTraces();
+class TracesHandlerRotationTest : public BaseFixture,
+                                  public ::testing::TestWithParam<std::pair<sf::Vector2f, float>> {
 
-  EXPECT_TRUE(actualTraces.empty());
-}
+};
 
-TEST_F(TracesHandlerTest, GivenMove_ThenTracesShouldContainSpriteWithHeightEqualToMoveHypot) {
-  sf::Vector2f move{3.f, 4.f};
+TEST_P(TracesHandlerRotationTest, GivenMove_ThenTraceShouldHaveOppositeRotation) {
+  const auto& [move, expected_rotation] = GetParam();
+
   mTankSprite.move(move);
   mHandler.update();
-  const float expectedRotation = get_angle(move);
-  const float expectedHeight = 5.f;
-  const auto& actualTraces = mHandler.getTraces();
+  const auto& actual_traces = mHandler.getTraces();
 
-  ASSERT_EQ(1, actualTraces.size());
-  const auto actualSpriteRotation = actualTraces.front().getRotation();
-  const auto actualSpriteHeight = actualTraces.front().getTextureRect().height;
+  ASSERT_EQ(1, actual_traces.size());
+  EXPECT_NEAR(expected_rotation, get_trace_rotation(actual_traces, 0), precision);
+}
 
-  EXPECT_EQ(expectedRotation, actualSpriteRotation);
-  EXPECT_EQ(expectedHeight, actualSpriteHeight);
+INSTANTIATE_TEST_CASE_P(RotationTestsWithManyValues, TracesHandlerRotationTest,
+                        ::testing::Values(std::make_pair(sf::Vector2f{2.f, 0.f}, 270.f),
+                                          std::make_pair(sf::Vector2f{2.f, 2.f}, 315.f),
+                                          std::make_pair(sf::Vector2f{0.f, 2.f}, 0.f),
+                                          std::make_pair(sf::Vector2f{-2.f, 2.f}, 45.f),
+                                          std::make_pair(sf::Vector2f{-2.f, -2.f}, 135.f)));
+
+class TracesHandlerTextureHeightTest
+    : public BaseFixture,
+      public ::testing::TestWithParam<std::pair<sf::Vector2f, int>> {};
+
+TEST_P(TracesHandlerTextureHeightTest, GivenMove_ThenTraceShouldHaveHeightEqualToMoveHypot) {
+  const auto& [move, expected_height] = GetParam();
+
+  mTankSprite.move(move);
+  mHandler.update();
+  const auto& actual_traces = mHandler.getTraces();
+
+  ASSERT_EQ(1, actual_traces.size());
+  EXPECT_NEAR(expected_height, get_trace_height(actual_traces, 0), precision);
+}
+
+INSTANTIATE_TEST_CASE_P(TextureHeightTestsWithManyValues, TracesHandlerTextureHeightTest,
+                        ::testing::Values(std::make_pair(sf::Vector2f{2.f, 0.f}, 2),
+                                          std::make_pair(sf::Vector2f{1.f, 1.f}, 1),
+                                          std::make_pair(sf::Vector2f{3.f, 4.f}, 5),
+                                          std::make_pair(sf::Vector2f{6.f, 8.f}, 10),
+                                          std::make_pair(sf::Vector2f{0.f, -2.f}, 2)));
+
+class TracesHandlerTest : public BaseFixture, public ::testing::Test {};
+
+TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
+  auto actual_traces = mHandler.getTraces();
+
+  EXPECT_TRUE(actual_traces.empty());
 }
 
 TEST_F(TracesHandlerTest,
-       GivenMovesWithSameAngle_ThenTracesShouldContainSpriteWithHeightEqualToSumOfMoveHypot) {
-  sf::Vector2f move{3.f, 4.f};
-  mTankSprite.move(move);
-  mHandler.update();
-  mTankSprite.move(move);
-  mHandler.update();
-  const float expectedRotation = get_angle(move);
-  const float expectedHeight = 10.f;
-  const auto& actualTraces = mHandler.getTraces();
+       GivenMovesWithSameAngle_ThenTraceShouldHaveHeightEqualToSumOfMoveHypotWithValueRounding) {
+  sf::Vector2f move1{1.f, 1.f};
+  sf::Vector2f move2{2.f, 2.f};
+  const int expected_height = 4;
 
-  ASSERT_EQ(1, actualTraces.size());
-  const auto actualSpriteHeight = actualTraces.front().getTextureRect().height;
-  const float actualSpriteRotation = actualTraces.front().getRotation();
+  mTankSprite.move(move1);
+  mHandler.update();
+  mTankSprite.move(move2);
+  mHandler.update();
 
-  EXPECT_EQ(expectedRotation, actualSpriteRotation);
-  EXPECT_EQ(expectedHeight, actualSpriteHeight);
+  const auto& actual_traces = mHandler.getTraces();
+
+  ASSERT_EQ(1, actual_traces.size());
+  EXPECT_EQ(expected_height, get_trace_height(actual_traces, 0));
 }
 
-TEST_F(
-    TracesHandlerTest,
-    GivenMovesWithDifferentAngle_ThenTracesShouldContainSeperateSpritesWithHeightEqualToMoveHypot) {
+TEST_F(TracesHandlerTest,
+       GivenMovesWithDifferentAngle_ThenAddSeperateTracesWithHeightEqualToMoveHypot) {
   sf::Vector2f move1{6.f, 0.f};
   sf::Vector2f move2{0.f, 14.f};
-  moveSprite(mTankSprite, move1);
-  mHandler.update();
-  moveSprite(mTankSprite, move2);
-  mHandler.update();
-  const float expectedRotation1 = 90.f;
-  const float expectedRotation2 = 180.f;
-  const float expectedHeight1 = 6.f;
-  const float expectedHeight2 = 14.f;
-  const sf::Vector2f expectedPosition1 = {-4.f, 0.f};
-  const sf::Vector2f expectedPosition2 = {6.f, 4.f};
-  const auto& actualTraces = mHandler.getTraces();
+  sf::Vector2f move3{-3.f, 4.f};
+  const int expected_height1 = 6;
+  const int expected_height2 = 14;
+  const int expected_height3 = 5;
 
-  ASSERT_EQ(2, actualTraces.size());
-  const float actualSpriteRotation1 = actualTraces[0].getRotation();
-  const float actualSpriteRotation2 = actualTraces[1].getRotation();
-  const auto actualSpriteHeight1 = actualTraces[0].getTextureRect().height;
-  const auto actualSpriteHeight2 = actualTraces[1].getTextureRect().height;
-  const auto actualSpritePosition1 = actualTraces[0].getPosition();
-  const auto actualSpritePosition2 = actualTraces[1].getPosition();
+  mTankSprite.move(move1);
+  mHandler.update();
+  mTankSprite.move(move2);
+  mHandler.update();
+  mTankSprite.move(move3);
+  mHandler.update();
 
-  EXPECT_EQ(expectedRotation1, actualSpriteRotation1);
-  EXPECT_EQ(expectedRotation2, actualSpriteRotation2);
-  EXPECT_EQ(expectedHeight1, actualSpriteHeight1);
-  EXPECT_EQ(expectedHeight2, actualSpriteHeight2);
-  expect_vec2f_eq(expectedPosition1, actualSpritePosition1);
-  expect_vec2f_eq(expectedPosition2, actualSpritePosition2);
+  const auto& actual_traces = mHandler.getTraces();
+
+  ASSERT_EQ(3, actual_traces.size());
+  EXPECT_EQ(expected_height1, get_trace_height(actual_traces, 0));
+  EXPECT_EQ(expected_height2, get_trace_height(actual_traces, 1));
+  EXPECT_EQ(expected_height3, get_trace_height(actual_traces, 2));
+}
+
+TEST_F(TracesHandlerTest,
+       GivenMoveLongerThanMaxTextureHeight_ThenSetCurrentSpriteHeightToMaxAndAddNewTrace) {
+  const float max_height = mHandler.get_max_texture_height();
+  sf::Vector2f move1{max_height - 1.f, 0.f};
+  sf::Vector2f move2{2.f, 0.f};
+  const int expected_height1 = max_height;
+  const int expected_height2 = 1.f;
+
+  mTankSprite.move(move1);
+  mHandler.update();
+  mTankSprite.move(move2);
+  mHandler.update();
+
+  const auto& actual_traces = mHandler.getTraces();
+
+  ASSERT_EQ(2, actual_traces.size());
+  EXPECT_EQ(expected_height1, get_trace_height(actual_traces, 0));
+  EXPECT_EQ(expected_height2, get_trace_height(actual_traces, 1));
 }

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -23,8 +23,8 @@ float get_trace_height(const std::deque<Trace>& traces, int idx) {
 
 class BaseFixture {
  protected:
-  uint mWidth{10};
-  uint mHeight{20};
+  unsigned int mWidth{10};
+  unsigned int mHeight{20};
   sf::Vector2f mStartPosition{0.f, 0.f};
   std::unique_ptr<sf::Texture> mTexture{create_dummy_texture(mWidth, mHeight)};
   int mMaxTracesAge{10};

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -4,13 +4,28 @@
 #include "TracesHandler.hpp"
 #include "utility.hpp"
 
+sf::Sprite setUpSprite(sf::Texture& tex) {
+  sf::Sprite sprite(tex);
+  const auto& [left, top, width, height] = sprite.getLocalBounds();
+  sprite.setOrigin(width / 2, height / 2);
+  sprite.setPosition({0.f, 0.f});
+  sprite.setRotation(0.f);
+  return sprite;
+}
+
+void moveSprite(sf::Sprite& sprite, const sf::Vector2f& move) {
+  sprite.move(move);
+  sprite.setRotation(get_angle(move));
+}
+
 class TracesHandlerTest : public ::testing::Test {
  protected:
   uint mWidth{10};
   uint mHeight{20};
   sf::Vector2f mStartPosition{0.f, 0.f};
   std::unique_ptr<sf::Texture> mTexture{create_dummy_texture(mWidth, mHeight)};
-  TracesHandler mHandler{*mTexture, mStartPosition};
+  sf::Sprite mTankSprite{setUpSprite(*mTexture)};
+  TracesHandler mHandler{*mTexture, mTankSprite};
 };
 
 TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
@@ -21,7 +36,8 @@ TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
 
 TEST_F(TracesHandlerTest, GivenMove_ThenTracesShouldContainSpriteWithHeightEqualToMoveHypot) {
   sf::Vector2f move{3.f, 4.f};
-  mHandler.update(move);
+  mTankSprite.move(move);
+  mHandler.update();
   const float expectedRotation = get_angle(move);
   const float expectedHeight = 5.f;
   const auto& actualTraces = mHandler.getTraces();
@@ -37,8 +53,10 @@ TEST_F(TracesHandlerTest, GivenMove_ThenTracesShouldContainSpriteWithHeightEqual
 TEST_F(TracesHandlerTest,
        GivenMovesWithSameAngle_ThenTracesShouldContainSpriteWithHeightEqualToSumOfMoveHypot) {
   sf::Vector2f move{3.f, 4.f};
-  mHandler.update(move);
-  mHandler.update(move);
+  mTankSprite.move(move);
+  mHandler.update();
+  mTankSprite.move(move);
+  mHandler.update();
   const float expectedRotation = get_angle(move);
   const float expectedHeight = 10.f;
   const auto& actualTraces = mHandler.getTraces();
@@ -54,14 +72,18 @@ TEST_F(TracesHandlerTest,
 TEST_F(
     TracesHandlerTest,
     GivenMovesWithDifferentAngle_ThenTracesShouldContainSeperateSpritesWithHeightEqualToMoveHypot) {
-  sf::Vector2f move1{6.f, 8.f};
-  sf::Vector2f move2{3.f, -4.f};
-  mHandler.update(move1);
-  mHandler.update(move2);
-  const float expectedRotation1 = get_angle(move1);
-  const float expectedRotation2 = get_angle(move2);
-  const float expectedHeight1 = 10.f;
-  const float expectedHeight2 = 5.f;
+  sf::Vector2f move1{6.f, 0.f};
+  sf::Vector2f move2{0.f, 14.f};
+  moveSprite(mTankSprite, move1);
+  mHandler.update();
+  moveSprite(mTankSprite, move2);
+  mHandler.update();
+  const float expectedRotation1 = 90.f;
+  const float expectedRotation2 = 180.f;
+  const float expectedHeight1 = 6.f;
+  const float expectedHeight2 = 14.f;
+  const sf::Vector2f expectedPosition1 = {-4.f, 0.f};
+  const sf::Vector2f expectedPosition2 = {6.f, 4.f};
   const auto& actualTraces = mHandler.getTraces();
 
   ASSERT_EQ(2, actualTraces.size());
@@ -69,9 +91,13 @@ TEST_F(
   const float actualSpriteRotation2 = actualTraces[1].getRotation();
   const auto actualSpriteHeight1 = actualTraces[0].getTextureRect().height;
   const auto actualSpriteHeight2 = actualTraces[1].getTextureRect().height;
+  const auto actualSpritePosition1 = actualTraces[0].getPosition();
+  const auto actualSpritePosition2 = actualTraces[1].getPosition();
 
   EXPECT_EQ(expectedRotation1, actualSpriteRotation1);
   EXPECT_EQ(expectedRotation2, actualSpriteRotation2);
   EXPECT_EQ(expectedHeight1, actualSpriteHeight1);
   EXPECT_EQ(expectedHeight2, actualSpriteHeight2);
+  expect_vec2f_eq(expectedPosition1, actualSpritePosition1);
+  expect_vec2f_eq(expectedPosition2, actualSpritePosition2);
 }

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -2,6 +2,7 @@
 
 #include "TestUtility.hpp"
 #include "TracesHandler.hpp"
+#include "utility.hpp"
 
 class TracesHandlerTest : public ::testing::Test {
  protected:
@@ -18,9 +19,59 @@ TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
   EXPECT_TRUE(actualTraces.empty());
 }
 
-TEST_F(TracesHandlerTest, GivenOneMove_ThenTracesShouldContainSprite) {
-  mHandler.update({3.f, 4.f});
-  auto actualTraces = mHandler.getTraces();
+TEST_F(TracesHandlerTest, GivenMove_ThenTracesShouldContainSpriteWithHeightEqualToMoveHypot) {
+  sf::Vector2f move{3.f, 4.f};
+  mHandler.update(move);
+  const float expectedRotation = get_angle(move);
+  const float expectedHeight = 5.f;
+  const auto& actualTraces = mHandler.getTraces();
 
-  EXPECT_EQ(1, actualTraces.size());
+  ASSERT_EQ(1, actualTraces.size());
+  const auto actualSpriteRotation = actualTraces.front().getRotation();
+  const auto actualSpriteHeight = actualTraces.front().getTextureRect().height;
+
+  EXPECT_EQ(expectedRotation, actualSpriteRotation);
+  EXPECT_EQ(expectedHeight, actualSpriteHeight);
+}
+
+TEST_F(TracesHandlerTest,
+       GivenMovesWithSameAngle_ThenTracesShouldContainSpriteWithHeightEqualToSumOfMoveHypot) {
+  sf::Vector2f move{3.f, 4.f};
+  mHandler.update(move);
+  mHandler.update(move);
+  const float expectedRotation = get_angle(move);
+  const float expectedHeight = 10.f;
+  const auto& actualTraces = mHandler.getTraces();
+
+  ASSERT_EQ(1, actualTraces.size());
+  const auto actualSpriteHeight = actualTraces.front().getTextureRect().height;
+  const float actualSpriteRotation = actualTraces.front().getRotation();
+
+  EXPECT_EQ(expectedRotation, actualSpriteRotation);
+  EXPECT_EQ(expectedHeight, actualSpriteHeight);
+}
+
+TEST_F(
+    TracesHandlerTest,
+    GivenMovesWithDifferentAngle_ThenTracesShouldContainSeperateSpritesWithHeightEqualToMoveHypot) {
+  sf::Vector2f move1{6.f, 8.f};
+  sf::Vector2f move2{3.f, -4.f};
+  mHandler.update(move1);
+  mHandler.update(move2);
+  const float expectedRotation1 = get_angle(move1);
+  const float expectedRotation2 = get_angle(move2);
+  const float expectedHeight1 = 10.f;
+  const float expectedHeight2 = 5.f;
+  const auto& actualTraces = mHandler.getTraces();
+
+  ASSERT_EQ(2, actualTraces.size());
+  const float actualSpriteRotation1 = actualTraces[0].getRotation();
+  const float actualSpriteRotation2 = actualTraces[1].getRotation();
+  const auto actualSpriteHeight1 = actualTraces[0].getTextureRect().height;
+  const auto actualSpriteHeight2 = actualTraces[1].getTextureRect().height;
+
+  EXPECT_EQ(expectedRotation1, actualSpriteRotation1);
+  EXPECT_EQ(expectedRotation2, actualSpriteRotation2);
+  EXPECT_EQ(expectedHeight1, actualSpriteHeight1);
+  EXPECT_EQ(expectedHeight2, actualSpriteHeight2);
 }

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include "TestUtility.hpp"
+#include "TracesHandler.hpp"
+
+class TracesHandlerTest : public ::testing::Test {
+ protected:
+  uint mWidth{10};
+  uint mHeight{20};
+  sf::Vector2f mStartPosition{0.f, 0.f};
+  std::unique_ptr<sf::Texture> mTexture{create_dummy_texture(mWidth, mHeight)};
+  TracesHandler mHandler{*mTexture, mStartPosition};
+};
+
+TEST_F(TracesHandlerTest, GivenFreshTracesHandler_ThenTracesShouldBeEmpty) {
+  auto actualTraces = mHandler.getTraces();
+
+  EXPECT_TRUE(actualTraces.empty());
+}
+
+TEST_F(TracesHandlerTest, GivenOneMove_ThenTracesShouldContainSprite) {
+  mHandler.update({3.f, 4.f});
+  auto actualTraces = mHandler.getTraces();
+
+  EXPECT_EQ(1, actualTraces.size());
+}

--- a/test/TracesHandlerTests.cpp
+++ b/test/TracesHandlerTests.cpp
@@ -152,8 +152,7 @@ TEST_F(TracesHandlerTest,
   ASSERT_NEAR(expected_height4, actual_height4, precision);
 }
 
-TEST_F(TracesHandlerTest,
-       WhenTraceHeightIsEqualOrLowerThanDecayValue_ThenRemoveTrace) {
+TEST_F(TracesHandlerTest, WhenTraceHeightIsEqualOrLowerThanDecayValue_ThenRemoveTrace) {
   sf::Vector2f move1{2.f, 0.f};
   const int expected_size1 = 1;
   const int expected_size2 = 0;

--- a/test/UtilityTests.cpp
+++ b/test/UtilityTests.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "TestUtility.hpp"
+#include "utility.hpp"
+#include "Size.hpp"
+#include "SquareRootEngine.hpp"
+
+struct GetAngleTestParam {
+  std::string testName{};
+  sf::Vector2f vector{};
+  float expectedDegrees{};
+
+  friend std::ostream& operator<<(std::ostream& os, const GetAngleTestParam& p) {
+      os << p.testName;
+      return os;
+  }
+};
+
+class GetAngleTests : public ::testing::TestWithParam<GetAngleTestParam> {};
+
+TEST_P(GetAngleTests, TestingGetAngleWithManyParameters) {
+  auto param = GetParam();
+
+  auto actualDegrees = get_angle(param.vector);
+
+  EXPECT_NEAR(param.expectedDegrees, actualDegrees, precision);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    GetAngleTestInstantiation, GetAngleTests,
+    ::testing::Values(GetAngleTestParam{
+        "Given: {1.f, -1.f} vector then return 45 degrees", {1.f, -1.f}, 45.f},
+        GetAngleTestParam{
+        "Given: {0.f, 0.f} vector then return 0 degrees", {0.f, 0.f}, 0.f},  
+        GetAngleTestParam{
+        "Given: {5.f, 0.f} vector then return 90 degrees", {5.f, 0.f}, 90.f}, 
+        GetAngleTestParam{
+        "Given: {0.f, 3.f} vector then return 180 degrees", {0.f, 3.f}, 180.f},
+        GetAngleTestParam{
+        "Given: {1.f, 1.f} vector then return 135 degrees", {1.f, 1.f}, 135.f},
+        GetAngleTestParam{
+        "Given: {0.f, -1.f} vector then return 0 degrees", {0.f, -1.f}, 0.f},
+        GetAngleTestParam{
+        "Given: {-1.f, 1.f} vector then return 225 degrees", {-1.f, 1.f}, 225.f},
+        GetAngleTestParam{
+        "Given: {-1.f, 0.f} vector then return 270 degrees", {-1.f, 0.f}, 270.f},
+        GetAngleTestParam{
+        "Given: {-1.f, -1.f} vector then return 315 degrees", {-1.f, -1.f}, 315.f},
+        GetAngleTestParam{
+        "Given: {-sqrt(3.f), -1.f} vector then return 300 degrees", {-sqrt(3.f), -1.f}, 300.f},
+         GetAngleTestParam{
+        "Given: {-1.f, -sqrt(3.f)} vector then return 330 degrees", {-1.f, -sqrt(3.f)}, 330.f}));
+
+
+TEST(GetAngleTest, GetAngleShouldComplementGetPositionDelta) {
+  SquareRootEngine engine(1, 2);
+  float expectedAngleRadians = pi / 4;
+  engine.set_gear(Gear::Drive);
+  engine.update();
+ 
+  auto actualAngleDegrees = get_angle(engine.get_position_delta(expectedAngleRadians));
+
+  EXPECT_NEAR(actualAngleDegrees, to_degrees(expectedAngleRadians), precision);
+}

--- a/test/UtilityTests.cpp
+++ b/test/UtilityTests.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
-#include "TestUtility.hpp"
-#include "utility.hpp"
 #include "Size.hpp"
 #include "SquareRootEngine.hpp"
+#include "TestUtility.hpp"
+#include "utility.hpp"
 
 struct GetAngleTestParam {
   std::string testName{};
@@ -11,8 +11,8 @@ struct GetAngleTestParam {
   float expectedDegrees{};
 
   friend std::ostream& operator<<(std::ostream& os, const GetAngleTestParam& p) {
-      os << p.testName;
-      return os;
+    os << p.testName;
+    return os;
   }
 };
 
@@ -28,36 +28,29 @@ TEST_P(GetAngleTests, TestingGetAngleWithManyParameters) {
 
 INSTANTIATE_TEST_CASE_P(
     GetAngleTestInstantiation, GetAngleTests,
-    ::testing::Values(GetAngleTestParam{
-        "Given: {1.f, -1.f} vector then return 45 degrees", {1.f, -1.f}, 45.f},
+    ::testing::Values(
+        GetAngleTestParam{"Given: {1.f, -1.f} vector then return 45 degrees", {1.f, -1.f}, 45.f},
+        GetAngleTestParam{"Given: {0.f, 0.f} vector then return 0 degrees", {0.f, 0.f}, 0.f},
+        GetAngleTestParam{"Given: {5.f, 0.f} vector then return 90 degrees", {5.f, 0.f}, 90.f},
+        GetAngleTestParam{"Given: {0.f, 3.f} vector then return 180 degrees", {0.f, 3.f}, 180.f},
+        GetAngleTestParam{"Given: {1.f, 1.f} vector then return 135 degrees", {1.f, 1.f}, 135.f},
+        GetAngleTestParam{"Given: {0.f, -1.f} vector then return 0 degrees", {0.f, -1.f}, 0.f},
+        GetAngleTestParam{"Given: {-1.f, 1.f} vector then return 225 degrees", {-1.f, 1.f}, 225.f},
+        GetAngleTestParam{"Given: {-1.f, 0.f} vector then return 270 degrees", {-1.f, 0.f}, 270.f},
         GetAngleTestParam{
-        "Given: {0.f, 0.f} vector then return 0 degrees", {0.f, 0.f}, 0.f},  
+            "Given: {-1.f, -1.f} vector then return 315 degrees", {-1.f, -1.f}, 315.f},
         GetAngleTestParam{
-        "Given: {5.f, 0.f} vector then return 90 degrees", {5.f, 0.f}, 90.f}, 
-        GetAngleTestParam{
-        "Given: {0.f, 3.f} vector then return 180 degrees", {0.f, 3.f}, 180.f},
-        GetAngleTestParam{
-        "Given: {1.f, 1.f} vector then return 135 degrees", {1.f, 1.f}, 135.f},
-        GetAngleTestParam{
-        "Given: {0.f, -1.f} vector then return 0 degrees", {0.f, -1.f}, 0.f},
-        GetAngleTestParam{
-        "Given: {-1.f, 1.f} vector then return 225 degrees", {-1.f, 1.f}, 225.f},
-        GetAngleTestParam{
-        "Given: {-1.f, 0.f} vector then return 270 degrees", {-1.f, 0.f}, 270.f},
-        GetAngleTestParam{
-        "Given: {-1.f, -1.f} vector then return 315 degrees", {-1.f, -1.f}, 315.f},
-        GetAngleTestParam{
-        "Given: {-sqrt(3.f), -1.f} vector then return 300 degrees", {-sqrt(3.f), -1.f}, 300.f},
-         GetAngleTestParam{
-        "Given: {-1.f, -sqrt(3.f)} vector then return 330 degrees", {-1.f, -sqrt(3.f)}, 330.f}));
-
+            "Given: {-sqrt(3.f), -1.f} vector then return 300 degrees", {-sqrt(3.f), -1.f}, 300.f},
+        GetAngleTestParam{"Given: {-1.f, -sqrt(3.f)} vector then return 330 degrees",
+                          {-1.f, -sqrt(3.f)},
+                          330.f}));
 
 TEST(GetAngleTest, GetAngleShouldComplementGetPositionDelta) {
   SquareRootEngine engine(1, 2);
   float expectedAngleRadians = pi / 4;
   engine.set_gear(Gear::Drive);
   engine.update();
- 
+
   auto actualAngleDegrees = get_angle(engine.get_position_delta(expectedAngleRadians));
 
   EXPECT_NEAR(actualAngleDegrees, to_degrees(expectedAngleRadians), precision);


### PR DESCRIPTION
This PR introduces new feature which displays traces after moving tank. 

Trace logic is contained in `TracesHandler` class, which is used by `Tank`. Logic in `TracesHandler` requires that tracks texture attribute `setRepeated` is true & texture must be loaded from the file using custom rectangle size. In order to decrease the number of overall draw calls when the tank is moving in the same direction  the track texture height is increased instead of adding new sprites each update. New sprite is added only when the tank changes move direction. TracesHandler allows setting 2 parameters:
- `mConfig.mMaxTraceAge`: the number of update calls before trace starts to dissapear
- `mConfig.mDecayRate`: controls how fast traces will dissapear (% value of maximum trace texture height)

`TracesHandler` uses internally `Trace` class, which is a lighter version of `sf::Sprite` which allows to increase / decrease it's internal texture height. sf::Sprite did not allow such flexibility, hence custom implementation.