### PR TITLE
Tank does not move out of the board

### DIFF
--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -147,8 +147,13 @@ void Tank::update() {
 
 void Tank::update_position() {
   const auto &delta = mEngine->get_position_delta(to_radians(mBody.get_rotation()));
-  mPos += delta;
-
+  const auto new_pos = mPos + delta;
+  if (is_sprite_x_in_board(new_pos.x, mBody.get_sprite())) {
+    mPos.x = new_pos.x;
+  }
+  if (is_sprite_y_in_board(new_pos.y, mBody.get_sprite())) {
+    mPos.y = new_pos.y;
+  }
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
   mShot.get_sprite().setPosition(mPos);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <SFML/Graphics/Sprite.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <cmath>
 #include <iostream>
@@ -38,4 +39,18 @@ inline float get_angle(const sf::Vector2f& vec) {
     return 360 + degrees;
   }
   return degrees;
+}
+
+inline bool is_sprite_x_in_board(const float x, const sf::Sprite& sp) {
+  const float sp_left_x_offset = fabs(sp.getOrigin().x - sp.getLocalBounds().left);
+  const float sp_right_x_offset =
+      fabs(sp.getOrigin().x - (sp.getLocalBounds().left + sp.getLocalBounds().width));
+  return x > sp_left_x_offset && x < WIDTH - sp_right_x_offset;
+}
+
+inline bool is_sprite_y_in_board(const float y, const sf::Sprite& sp) {
+  const float sp_top_y_offset = fabs(sp.getOrigin().y - sp.getLocalBounds().top);
+  const float sp_bot_y_offset =
+      fabs(sp.getOrigin().y - (sp.getLocalBounds().top + sp.getLocalBounds().height));
+  return y > sp_top_y_offset && y < HEIGHT - sp_bot_y_offset;
 }

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -60,10 +60,10 @@ TEST_F(TankTest, Given1UpdateWhenGetPositionThenReturnsPositionDelta) {
 }
 
 TEST_F(TankTest, GivenMultipleUpdatesWhenGetPositionThenReturnsPositionDeltaSum) {
-  const sf::Vector2f single_move = {3.f, -7.f};
+  const sf::Vector2f single_move = {3.f, 5.f};
   EXPECT_CALL(*mEngineNiceMock, get_position_delta).WillRepeatedly(testing::Return(single_move));
   const int update_count = 3;
-  const sf::Vector2f expected_position = {9.f, -21.f};
+  const sf::Vector2f expected_position = {9.f, 15.f};
 
   update_many(mTankSUT, update_count);
 
@@ -77,4 +77,26 @@ TEST_F(TankTest, RotateTower_ShouldntAffectMoving) {
   mTankSUT.rotate_tower(Rotation::Clockwise);
   mTankSUT.rotate_tower(Rotation::Clockwise);
   mTankSUT.update();
+}
+
+TEST_F(TankTest, WhenTankMoves_ThenItShouldNotMoveOutOfTheBoard) {
+  mAngle = 315.f;
+  EXPECT_CALL(*mEngineNiceMock, get_position_delta(to_radians(mAngle)))
+      .WillRepeatedly(testing::Return(sf::Vector2f{-5.f, -5.f}));
+  mTankSUT.set_rotation(mAngle);
+  mTankSUT.set_gear(Gear::Drive);
+
+  update_many(mTankSUT, 100);
+
+  expect_vec2f_eq({0.f, 0.f}, mTankSUT.get_position());
+}
+
+TEST_F(TankTest, WhenTankIsOneAxisOutOfTheBoard_ThenShouldAllowToMoveOnlyOneAxis) {
+  EXPECT_CALL(*mEngineNiceMock, get_position_delta(testing::_))
+      .WillRepeatedly(testing::Return(sf::Vector2f{-5.f, 5.f}));
+  mTankSUT.set_gear(Gear::Drive);
+
+  update_many(mTankSUT, 100);
+
+  expect_vec2f_eq({0.f, 500.f}, mTankSUT.get_position());
 }


### PR DESCRIPTION
Tests & implementation

- New border checking functions added to utility.hpp
- Tank::update_position performs position checks based on functions from utility.hpp