### PR TITLE
Fix macOS compilation error

### DIFF
--- a/.github/workflows/macos_clang.yaml
+++ b/.github/workflows/macos_clang.yaml
@@ -25,11 +25,10 @@ jobs:
         run: git lfs checkout
 
       - name: Install vcpkg packages
-        # vcpkg does not compile with macos-clang, use default gcc :|
+        # vcpkg binary can only be compiled using gcc for now (bootstrap step)
         run: |
-          ./vcpkg/bootstrap-vcpkg.sh
-          ./vcpkg/vcpkg install
-
+         ./vcpkg/bootstrap-vcpkg.sh
+         
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -40,11 +39,17 @@ jobs:
           CXX: /usr/local/opt/llvm/bin/clang++
         working-directory: ${{runner.workspace}}/build
         run: |
-          clang --version
-          clang++ --version
+          ${CC} --version
+          ${CXX} --version
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: cmake --build . --config $BUILD_TYPE
+        env:
+          CC: /usr/local/opt/llvm/bin/clang
+          CXX: /usr/local/opt/llvm/bin/clang++
+        run: |
+          ${CC} --version
+          ${CXX} --version
+          cmake --build . --config $BUILD_TYPE

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,12 @@
 {
   "name": "tank-bot-fight",
   "version-string": "0.0.1",
+  "builtin-baseline": "50fd3d9957195575849a49fa591e645f1d8e7156",
   "dependencies": [
     "sfml",
-    "range-v3"
+    {
+       "name": "range-v3",
+       "version>=": "2021-11-02"
+    }
   ]
 }


### PR DESCRIPTION
- vcpkg.json is modified to use range_v3 version from latest commit on day 2021-11-02 (contains patch for clang 13.0.0 libc++)
- macos_clang.yaml is modified to bootstrap vcpkg using gcc instead of clang
- vcpkg_install step is removed because it is redundant (during cmake configuration all packages are compiled & installed by clang 13.0.0)
- vcpkg submodule is updated to use commit 50fd3d9957195575849a49fa591e645f1d8e7156 (2021-12-17)