### PR TITLE
Clang tidy readability refactor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,501 @@
+---
+Checks:          ''
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             bugprone-reserved-identifier.Invert
+    value:           'false'
+  - key:             bugprone-narrowing-conversions.PedanticMode
+    value:           'false'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty;::std::back_inserter;::std::distance;::std::find;::std::find_if;::std::inserter;::std::lower_bound;::std::make_pair;::std::map::count;::std::map::find;::std::map::lower_bound;::std::multimap::equal_range;::std::multimap::upper_bound;::std::set::count;::std::set::find;::std::setfill;::std::setprecision;::std::setw;::std::upper_bound;::std::vector::at;::bsearch;::ferror;::feof;::isalnum;::isalpha;::isblank;::iscntrl;::isdigit;::isgraph;::islower;::isprint;::ispunct;::isspace;::isupper;::iswalnum;::iswprint;::iswspace;::isxdigit;::memchr;::memcmp;::strcmp;::strcoll;::strncmp;::strpbrk;::strrchr;::strspn;::strstr;::wcscmp;::access;::bind;::connect;::difftime;::dlsym;::fnmatch;::getaddrinfo;::getopt;::htonl;::htons;::iconv_open;::inet_addr;::isascii;::isatty;::mmap;::newlocale;::openat;::pathconf;::pthread_equal;::pthread_getspecific;::pthread_mutex_trylock;::readdir;::readlink;::recvmsg;::regexec;::scandir;::semget;::setjmp;::shm_open;::shmget;::sigismember;::strcasecmp;::strsignal;::ttyname'
+  - key:             cert-dcl51-cpp.AggressiveDependentMemberLookup
+    value:           'false'
+  - key:             hicpp-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             readability-inconsistent-declaration-parameter-name.Strict
+    value:           'false'
+  - key:             hicpp-use-override.IgnoreDestructors
+    value:           'false'
+  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
+    value:           'false'
+  - key:             cert-dcl37-c.AllowedIdentifiers
+    value:           ''
+  - key:             modernize-replace-disallow-copy-and-assign-macro.MacroName
+    value:           DISALLOW_COPY_AND_ASSIGN
+  - key:             hicpp-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             hicpp-member-init.IgnoreArrays
+    value:           'false'
+  - key:             hicpp-use-override.AllowOverrideAndFinal
+    value:           'false'
+  - key:             hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
+    value:           'false'
+  - key:             cert-err09-cpp.WarnOnLargeObjects
+    value:           'false'
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           'true'
+  - key:             bugprone-argument-comment.CommentNullPtrs
+    value:           '0'
+  - key:             cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
+    value:           'true'
+  - key:             hicpp-use-equals-delete.IgnoreMacros
+    value:           'true'
+  - key:             cppcoreguidelines-init-variables.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nodiscard.ReplacementString
+    value:           '[[nodiscard]]'
+  - key:             modernize-loop-convert.MakeReverseRangeHeader
+    value:           ''
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ';h;hh;hpp;hxx'
+  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
+    value:           'L;LL;LU;LLU;UL;ULL'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             modernize-loop-convert.UseCxx20ReverseRanges
+    value:           'true'
+  - key:             hicpp-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             cert-oop57-cpp.MemSetNames
+    value:           ''
+  - key:             hicpp-no-malloc.Deallocations
+    value:           '::free'
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             bugprone-suspicious-include.ImplementationFileExtensions
+    value:           'c;cc;cpp;cxx'
+  - key:             modernize-loop-convert.MakeReverseRangeFunction
+    value:           ''
+  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
+    value:           'true'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           'false'
+  - key:             hicpp-multiway-paths-covered.WarnOnMissingElse
+    value:           'false'
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           'true'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           'true'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           'true'
+  - key:             hicpp-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
+    value:           override
+  - key:             hicpp-use-noexcept.UseNoexceptFalse
+    value:           'true'
+  - key:             readability-uppercase-literal-suffix.IgnoreMacros
+    value:           'true'
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           'L;LL;LU;LLU;UL;ULL'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ';h;hh;hpp;hxx'
+  - key:             bugprone-dynamic-static-initializers.HeaderFileExtensions
+    value:           ';h;hh;hpp;hxx'
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           'true'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           'false'
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           ''
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           'false'
+  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    value:           'true'
+  - key:             bugprone-not-null-terminated-result.WantToUseSafeFunctions
+    value:           'true'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           'false'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
+    value:           'false'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           'true'
+  - key:             performance-inefficient-vector-operation.EnableProto
+    value:           'false'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             bugprone-argument-comment.CommentStringLiterals
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             portability-simd-intrinsics.Suggest
+    value:           'false'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           '<memory>'
+  - key:             modernize-use-override.IgnoreDestructors
+    value:           'false'
+  - key:             misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
+    value:           'false'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           'true'
+  - key:             readability-redundant-string-init.StringNames
+    value:           '::std::basic_string_view;::std::basic_string'
+  - key:             modernize-make-unique.IgnoreDefaultInitialization
+    value:           'true'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             readability-magic-numbers.IgnoreBitFieldsWidths
+    value:           'true'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-override.OverrideSpelling
+    value:           override
+  - key:             concurrency-mt-unsafe.FunctionSet
+    value:           any
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             bugprone-reserved-identifier.AllowedIdentifiers
+    value:           ''
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           'false'
+  - key:             readability-else-after-return.WarnOnUnfixable
+    value:           'true'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;2.0;'
+  - key:             modernize-use-emplace.IgnoreImplicitConstructors
+    value:           'false'
+  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
+    value:           'true'
+  - key:             modernize-use-equals-delete.IgnoreMacros
+    value:           'true'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           llvm
+  - key:             readability-magic-numbers.IgnoreAllFloatingPointValues
+    value:           'false'
+  - key:             hicpp-use-auto.RemoveStars
+    value:           'false'
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           ''
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           'true'
+  - key:             misc-throw-by-value-catch-by-reference.MaxSize
+    value:           '8'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
+    value:           'false'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths
+    value:           'true'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           'true'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             cppcoreguidelines-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             hicpp-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           'false'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             hicpp-use-noexcept.ReplacementString
+    value:           ''
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           'false'
+  - key:             cppcoreguidelines-init-variables.MathHeader
+    value:           '<math.h>'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             cert-msc51-cpp.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             hicpp-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             bugprone-reserved-identifier.AggressiveDependentMemberLookup
+    value:           'false'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           'true'
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           'false'
+  - key:             cert-dcl37-c.AggressiveDependentMemberLookup
+    value:           'false'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             cppcoreguidelines-no-malloc.Deallocations
+    value:           '::free'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             readability-magic-numbers.IgnorePowersOf2IntegerValues
+    value:           'false'
+  - key:             misc-unused-parameters.StrictMode
+    value:           'false'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             readability-simplify-subscript-expr.Types
+    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           'true'
+  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value:           'true'
+  - key:             readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             bugprone-narrowing-conversions.WarnOnFloatingPointNarrowingConversion
+    value:           'true'
+  - key:             readability-identifier-naming.GetConfigPerFile
+    value:           'true'
+  - key:             cert-err61-cpp.MaxSize
+    value:           '8'
+  - key:             hicpp-member-init.UseAssignment
+    value:           'false'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           'false'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             modernize-use-override.AllowOverrideAndFinal
+    value:           'false'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           'false'
+  - key:             modernize-loop-convert.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           'false'
+  - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
+    value:           'false'
+  - key:             hicpp-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-redundant-smartptr-get.IgnoreMacros
+    value:           'true'
+  - key:             readability-identifier-naming.AggressiveDependentMemberLookup
+    value:           'false'
+  - key:             cert-err61-cpp.WarnOnLargeObjects
+    value:           'false'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             hicpp-use-emplace.IgnoreImplicitConstructors
+    value:           'false'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  - key:             hicpp-uppercase-literal-suffix.IgnoreMacros
+    value:           'true'
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'false'
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-bool-literals.IgnoreMacros
+    value:           'true'
+  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value:           'true'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             hicpp-use-override.OverrideSpelling
+    value:           override
+  - key:             modernize-avoid-bind.PermissiveParameterList
+    value:           'false'
+  - key:             modernize-use-override.FinalSpelling
+    value:           final
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             cert-err09-cpp.MaxSize
+    value:           '8'
+  - key:             hicpp-use-equals-default.IgnoreMacros
+    value:           'true'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-using.IgnoreMacros
+    value:           'true'
+  - key:             hicpp-use-override.FinalSpelling
+    value:           final
+  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
+    value:           final
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
+    value:           'false'
+  - key:             bugprone-suspicious-include.HeaderFileExtensions
+    value:           ';h;hh;hpp;hxx'
+  - key:             hicpp-function-size.StatementThreshold
+    value:           '800'
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           'false'
+  - key:             bugprone-argument-comment.CommentCharacterLiterals
+    value:           '0'
+  - key:             performance-no-automatic-move.AllowedTypes
+    value:           ''
+  - key:             hicpp-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             bugprone-argument-comment.CommentIntegerLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentFloatLiterals
+    value:           '0'
+  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
+    value:           '16'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           'false'
+  - key:             readability-else-after-return.WarnOnConditionVariables
+    value:           'true'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
+    value:           '^DEBUG_*'
+  - key:             cppcoreguidelines-narrowing-conversions.PedanticMode
+    value:           'false'
+  - key:             modernize-make-shared.IgnoreDefaultInitialization
+    value:           'true'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           llvm
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
+    value:           'false'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value:           'false'
+  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
+    value:           ''
+  - key:             cert-dcl51-cpp.Invert
+    value:           'false'
+  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
+    value:           'false'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           'true'
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           'true'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             hicpp-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             bugprone-argument-comment.CommentBoolLiterals
+    value:           '0'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
+    value:           '0'
+  - key:             hicpp-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
+    value:           'false'
+  - key:             readability-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;2.0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           'false'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           'false'
+  - key:             readability-redundant-declaration.IgnoreMacros
+    value:           'true'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             hicpp-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             portability-restrict-system-includes.Includes
+    value:           '*'
+  - key:             cert-dcl51-cpp.AllowedIdentifiers
+    value:           ''
+  - key:             cert-oop57-cpp.MemCpyNames
+    value:           ''
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           '<memory>'
+  - key:             hicpp-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables
+    value:           'false'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
+    value:           'false'
+  - key:             cert-oop57-cpp.MemCmpNames
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           'true'
+  - key:             readability-function-cognitive-complexity.Threshold
+    value:           '25'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             bugprone-argument-comment.IgnoreSingleArgument
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           'false'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           '::std::basic_string;::std::basic_string_view'
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           'false'
+  - key:             bugprone-string-constructor.StringNames
+    value:           '::std::basic_string;::std::basic_string_view'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons
+    value:           'true'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           'true'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             cert-str34-c.CharTypdefsToIgnore
+    value:           ''
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           'true'
+  - key:             modernize-raw-string-literal.DelimiterStem
+    value:           lit
+  - key:             misc-throw-by-value-catch-by-reference.WarnOnLargeObjects
+    value:           'false'
+  - key:             cert-dcl37-c.Invert
+    value:           'false'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           'false'
+  - key:             readability-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             modernize-use-auto.RemoveStars
+    value:           'false'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             portability-simd-intrinsics.Std
+    value:           ''
+  - key:             hicpp-use-nullptr.NullMacros
+    value:           ''
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           'false'
+  - key:             cert-dcl16-c.IgnoreMacros
+    value:           'true'
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             cert-msc32-c.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+...
+

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -16,7 +16,7 @@ function(add_tidy_target TIDY_VERSION)
     -clang-tidy-binary
     ${CLANG_TIDY_BIN}
     -header-filter=.*
-    -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*
+    -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
     -p=${CMAKE_BINARY_DIR}
     ${add_tidy_target_FILES}
     )

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -9,7 +9,6 @@
 #include "SquareRootEngine.hpp"
 #include "TracesHandler.hpp"
 
-
 Board::Board() : mWindow(sf::VideoMode(WIDTH, HEIGHT), "TankBotFight"), mBackground(mStore) {
   mWindow.setFramerateLimit(30);
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -9,12 +9,18 @@
 #include "SquareRootEngine.hpp"
 #include "TracesHandler.hpp"
 
+
 Board::Board() : mWindow(sf::VideoMode(WIDTH, HEIGHT), "TankBotFight"), mBackground(mStore) {
   mWindow.setFramerateLimit(30);
 }
 
 void Board::register_tank() {
   using namespace std::string_literals;
+  const sf::IntRect TRACKS_TEXTURE_RECT = {0, 0, 37, 48};
+  constexpr float TANK_X = WIDTH / 2.0f;
+  constexpr float TANK_Y = 50.f;
+  constexpr int STEP_COUNT = 70;
+  constexpr float MAX_SPEED = 5.f;
   auto& body_texture = mStore.get_texture(one_of("tankBody_red.png"s, "tankBody_dark.png"s,
                                                  "tankBody_blue.png"s, "tankBody_green.png"s));
   body_texture.setSmooth(true);
@@ -24,13 +30,12 @@ void Board::register_tank() {
   tower_texture.setSmooth(true);
   auto& shot_texture = mStore.get_texture("shotOrange.png");
   shot_texture.setSmooth(true);
-  auto& tracks_texture = mStore.get_texture("tracksSmall.png", {0, 0, 37, 48});
+  auto& tracks_texture = mStore.get_texture("tracksSmall.png", TRACKS_TEXTURE_RECT);
   tracks_texture.setSmooth(true);
   tracks_texture.setRepeated(true);
-  auto tank = Tank(WIDTH / 2.0f, 50.0f, body_texture, tower_texture, shot_texture, tracks_texture,
-                   std::make_unique<SquareRootEngine>(70, 5.f),
+  auto tank = Tank(TANK_X, TANK_Y, body_texture, tower_texture, shot_texture, tracks_texture,
+                   std::make_unique<SquareRootEngine>(STEP_COUNT, MAX_SPEED),
                    TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f});
-  tank.set_rotation(180);
   mTanks.emplace_back(std::move(tank));
   mFont.loadFromFile(files::asset_path() + "DejaVuSans.ttf");
   mText.setFont(mFont);

--- a/src/KeyboardController.cpp
+++ b/src/KeyboardController.cpp
@@ -6,55 +6,66 @@
 #include "Engine.hpp"
 #include "Tank.hpp"
 
+
 KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {
   mLastShot = std::chrono::system_clock::now();
 }
 
+void KeyboardController::handle_shot() {
+  const auto now = std::chrono::system_clock::now();
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
+  constexpr auto SHOT_COOLDOWN = std::chrono::milliseconds{500};
+  if (elapsed >= SHOT_COOLDOWN) {
+    mLastShot = now;
+    mBoard.fire_missle(mTank.get_tower_rotation(), mTank.get_position().x, mTank.get_position().y);
+    mTank.shot();
+  }
+}
+
 void KeyboardController::update(const sf::Event& event) {
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::A) {
-    mTank.rotate_body(Rotation::Counterclockwise);
+  if (event.type == sf::Event::KeyPressed) {
+    switch (event.key.code) {
+      case sf::Keyboard::A:
+        mTank.rotate_body(Rotation::Counterclockwise);
+        break;
+      case sf::Keyboard::D:
+        mTank.rotate_body(Rotation::Clockwise);
+        break;
+      case sf::Keyboard::Left:
+        mTank.rotate_tower(Rotation::Counterclockwise);
+        break;
+      case sf::Keyboard::Right:
+        mTank.rotate_tower(Rotation::Clockwise);
+        break;
+      case sf::Keyboard::W:
+        mTank.set_gear(Gear::Drive);
+        break;
+      case sf::Keyboard::S:
+        mTank.set_gear(Gear::Reverse);
+        break;
+      case sf::Keyboard::Space:
+        handle_shot();
+        break;
+      default:
+        break;
+    }
   }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::A) {
-    mTank.rotate_body(Rotation::None);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::D) {
-    mTank.rotate_body(Rotation::Clockwise);
-  }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::D) {
-    mTank.rotate_body(Rotation::None);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Left) {
-    mTank.rotate_tower(Rotation::Counterclockwise);
-  }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::Left) {
-    mTank.rotate_tower(Rotation::None);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Right) {
-    mTank.rotate_tower(Rotation::Clockwise);
-  }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::Right) {
-    mTank.rotate_tower(Rotation::None);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::W) {
-    mTank.set_gear(Gear::Drive);
-  }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::W) {
-    mTank.set_gear(Gear::Neutral);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::S) {
-    mTank.set_gear(Gear::Reverse);
-  }
-  if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::S) {
-    mTank.set_gear(Gear::Neutral);
-  }
-  if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Space) {
-    const auto now = std::chrono::system_clock::now();
-    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
-    if (elapsed >= std::chrono::milliseconds{500}) {
-      mLastShot = now;
-      mBoard.fire_missle(mTank.get_tower_rotation(), mTank.get_position().x,
-                         mTank.get_position().y);
-      mTank.shot();
+  if (event.type == sf::Event::KeyReleased) {
+    switch (event.key.code) {
+      case sf::Keyboard::A:
+      case sf::Keyboard::D:
+        mTank.rotate_body(Rotation::None);
+        break;
+      case sf::Keyboard::Left:
+      case sf::Keyboard::Right:
+        mTank.rotate_tower(Rotation::None);
+        break;
+      case sf::Keyboard::W:
+      case sf::Keyboard::S:
+        mTank.set_gear(Gear::Neutral);
+        break;
+      default:
+        break;
     }
   }
 }

--- a/src/KeyboardController.cpp
+++ b/src/KeyboardController.cpp
@@ -6,7 +6,6 @@
 #include "Engine.hpp"
 #include "Tank.hpp"
 
-
 KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {
   mLastShot = std::chrono::system_clock::now();
 }

--- a/src/KeyboardController.hpp
+++ b/src/KeyboardController.hpp
@@ -13,6 +13,7 @@ class KeyboardController {
   void update(const sf::Event& event);
 
  private:
+  void handle_shot();
   Tank& mTank;
   Board& mBoard;
   std::chrono::milliseconds mLastDelay{0};

--- a/src/Obstacle.cpp
+++ b/src/Obstacle.cpp
@@ -10,7 +10,6 @@
 
 #include <stdexcept>
 
-
 Obstacle::Obstacle(int x, int y) {
   if (!mTxt.loadFromFile("../res/przeszkoda-obedience.jpg")) {
     throw std::runtime_error("Cannot read graphic file!");

--- a/src/Obstacle.cpp
+++ b/src/Obstacle.cpp
@@ -10,6 +10,7 @@
 
 #include <stdexcept>
 
+
 Obstacle::Obstacle(int x, int y) {
   if (!mTxt.loadFromFile("../res/przeszkoda-obedience.jpg")) {
     throw std::runtime_error("Cannot read graphic file!");
@@ -19,7 +20,8 @@ Obstacle::Obstacle(int x, int y) {
 
   mSprite.setPosition(static_cast<float>(x), static_cast<float>(y));
 
-  mSprite.scale(0.1f, 0.1f);
+  constexpr float SCALE_FACTOR = 0.1f;
+  mSprite.scale(SCALE_FACTOR, SCALE_FACTOR);
 }
 
 sf::Sprite Obstacle::get_sprite() { return mSprite; }

--- a/src/Random.hpp
+++ b/src/Random.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <vector>
 
-int random_range(const int begin, const int end);
+int random_range(int begin, int end);
 
 template <typename T, typename... Args>
 T one_of(T first, Args... rest) {

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -194,8 +194,10 @@ void Tank::draw(sf::RenderWindow &window) {
 void Tank::draw_shot(sf::RenderWindow &window) {
   auto get_shot_animation_pos = [x = mPos.x, y = mPos.y](float tower_rotation) {
     return sf::Vector2f{
-        x + SHOT_ANIMATION_DISTANCE * static_cast<float>(cos(to_radians(tower_rotation - ROTATION_OFFSET))),
-        y + SHOT_ANIMATION_DISTANCE * static_cast<float>(sin(to_radians(tower_rotation - ROTATION_OFFSET)))};
+        x + SHOT_ANIMATION_DISTANCE *
+                static_cast<float>(cos(to_radians(tower_rotation - ROTATION_OFFSET))),
+        y + SHOT_ANIMATION_DISTANCE *
+                static_cast<float>(sin(to_radians(tower_rotation - ROTATION_OFFSET)))};
   };
   const auto shot_animation_pos = get_shot_animation_pos(mTower.get_rotation());
   mShot.draw(window, shot_animation_pos.x, shot_animation_pos.y);

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -6,6 +6,12 @@
 #include "TextureStore.hpp"
 #include "utility.hpp"
 
+constexpr int TANK_INITIAL_ROTATION = 180;
+constexpr int ROTATION_OFFSET = 90;
+constexpr int TANK_PART_ROTATE = 10;
+constexpr int SHOT_ANIMATION_DISTANCE = 30;
+constexpr std::chrono::milliseconds SHOT_ANIMATION_DURATION = std::chrono::milliseconds(100);
+
 TankPart::TankPart(sf::Texture &texture) {
   mSprite.setTexture(texture);
   const auto [width, height] = texture.getSize();
@@ -25,10 +31,10 @@ const sf::Sprite &TankPart::get_sprite() const { return mSprite; }
 void TankPart::update() {
   switch (mRotation) {
     case Rotation::Clockwise:
-      mSprite.rotate(10);
+      mSprite.rotate(TANK_PART_ROTATE);
       break;
     case Rotation::Counterclockwise:
-      mSprite.rotate(-10);
+      mSprite.rotate(-TANK_PART_ROTATE);
       break;
     case Rotation::None:
       break;
@@ -50,7 +56,7 @@ Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture 
       mEngine(std::move(engine)),
       mTracesHandler(std::make_unique<TracesHandler>(tracks, mBody.get_sprite(), mPos,
                                                      traces_handler_config)) {
-  set_rotation(180);
+  set_rotation(TANK_INITIAL_ROTATION);
   mBody.get_sprite().setPosition(mPos);
   mTower.get_sprite().setPosition(mPos);
   mShot.get_sprite().setPosition(mPos);
@@ -188,8 +194,8 @@ void Tank::draw(sf::RenderWindow &window) {
 void Tank::draw_shot(sf::RenderWindow &window) {
   auto get_shot_animation_pos = [x = mPos.x, y = mPos.y](float tower_rotation) {
     return sf::Vector2f{
-        x + SHOT_ANIMATION_DISTANCE * static_cast<float>(cos(to_radians(tower_rotation - 90))),
-        y + SHOT_ANIMATION_DISTANCE * static_cast<float>(sin(to_radians(tower_rotation - 90)))};
+        x + SHOT_ANIMATION_DISTANCE * static_cast<float>(cos(to_radians(tower_rotation - ROTATION_OFFSET))),
+        y + SHOT_ANIMATION_DISTANCE * static_cast<float>(sin(to_radians(tower_rotation - ROTATION_OFFSET)))};
   };
   const auto shot_animation_pos = get_shot_animation_pos(mTower.get_rotation());
   mShot.draw(window, shot_animation_pos.x, shot_animation_pos.y);

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -10,8 +10,6 @@
 #include "TracesHandler.hpp"
 
 enum class Rotation { None, Clockwise, Counterclockwise };
-inline constexpr int SHOT_ANIMATION_DISTANCE = 30;
-inline constexpr std::chrono::milliseconds SHOT_ANIMATION_DURATION = std::chrono::milliseconds(100);
 
 class TankPart {
  public:
@@ -47,7 +45,7 @@ class Tank {
   void set_rotation(const int angle);
 
   void set_gear(Gear gear);
-  void draw(sf::RenderWindow& draw);
+  void draw(sf::RenderWindow&);
   void update();
   void shot();
 
@@ -59,8 +57,8 @@ class Tank {
   inline constexpr static float M_SPEED = 0.01f;
   void update_shot();
   void update_position();
-  void draw_shot(sf::RenderWindow& draw);
-  void draw_tracks(sf::RenderWindow& draw);
+  void draw_shot(sf::RenderWindow&);
+  void draw_tracks(sf::RenderWindow&);
 
   sf::Vector2f mPos;
   float mCurrentSpeed = 0.0f;

--- a/src/TextureStore.hpp
+++ b/src/TextureStore.hpp
@@ -12,7 +12,7 @@ class TextureStore {
   TextureStore& operator=(TextureStore&&) = delete;
   ~TextureStore() = default;
 
-  sf::Texture& get_texture(const std::string& file, const sf::IntRect& = sf::IntRect{});
+  sf::Texture& get_texture(const std::string& path, const sf::IntRect& = sf::IntRect{});
 
  private:
   std::unordered_map<std::string, sf::Texture> mStore;

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -15,18 +15,18 @@ sf::Vector2f get_middle_bot_transform(const sf::Sprite& sprite,
       {left + width / 2.f, top + height + additional_value});
 }
 
-TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tank_sprite,
+TracesHandler::TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite,
                              const sf::Vector2f& start_pos, const TracesHandlerConfig& config)
-    : mTracksTexture(texture),
+    : mTracksTexture(tracks),
       mTankSprite(tank_sprite),
       mLastTankPos(start_pos),
       mMaxTextureHeight(mTracksTexture.getSize().y),
       mConfig(config) {}
 
-TracesHandler::TracesHandler(const sf::Texture& texture, sf::Sprite& tank_sprite,
+TracesHandler::TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite,
                              const sf::Vector2f& start_pos, const int max_trace_age,
                              const float decay_rate)
-    : TracesHandler(texture, tank_sprite, start_pos,
+    : TracesHandler(tracks, tank_sprite, start_pos,
                     TracesHandlerConfig{.mMaxTraceAge = max_trace_age, .mDecayRate = decay_rate}) {}
 
 const std::deque<Trace>& TracesHandler::get_traces() const { return mTraces; }
@@ -59,7 +59,7 @@ void TracesHandler::update_traces_age() {
 }
 
 void TracesHandler::decay_traces() {
-  if (mTracesAge.size() <= 0) {
+  if (mTracesAge.empty()) {
     return;
   }
   if (mTracesAge.front() >= mConfig.mMaxTraceAge) {
@@ -86,14 +86,6 @@ void TracesHandler::remove_trace() {
 bool TracesHandler::is_move_angle_changed(const sf::Vector2f& move) const {
   return !mTraces.empty() &&
          !equal(mTraces.back().get_rotation(), get_opposite_angle(get_angle(move)), 1.0);
-}
-
-float TracesHandler::get_opposite_angle(const float angle) const {
-  float opposite_angle = angle - 180.f;
-  if (opposite_angle < 0.f) {
-    opposite_angle = 360.f + opposite_angle;
-  }
-  return opposite_angle;
 }
 
 Trace TracesHandler::make_trace(const sf::Vector2f& move) const {

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -21,10 +21,9 @@ class TracesHandler {
 
   void update_traces_age();
   void decay_traces();
-  void add_trace(const Trace& sp);
+  void add_trace(const Trace&);
   void remove_trace();
   bool is_move_angle_changed(const sf::Vector2f& move) const;
-  float get_opposite_angle(const float angle) const;
   Trace make_trace(const sf::Vector2f& move) const;
   bool is_moving_forward(const sf::Vector2f&) const;
 

--- a/src/background/Background.cpp
+++ b/src/background/Background.cpp
@@ -22,7 +22,7 @@ Background::Background(TextureStore& store) : mTextureStore(store), mGround(FIEL
 
   for (int i = 0; i < FIELDS_HEIGHT; ++i) {
     for (int j = 0; j < FIELDS_WIDTH; ++j) {
-      mGround[i].emplace_back(mTextureStore.get_texture(get_texture_name(grounds, i, j)));
+      mGround[i].emplace_back(mTextureStore.get_texture(BackgroundTextureName::get(grounds, i, j)));
     }
   }
 }
@@ -33,8 +33,4 @@ void Background::draw(sf::RenderWindow& window) {
       mGround[i][j].draw(window, j * GROUND_HEIGHT, i * GROUND_WIDTH);
     }
   }
-}
-
-std::string Background::get_texture_name(const GroundTypeVec& v, int x, int y) {
-  return BackgroundTextureName::get(v, x, y);
 }

--- a/src/background/Background.hpp
+++ b/src/background/Background.hpp
@@ -17,8 +17,6 @@ class Background {
   using GroundTypeVec = std::vector<std::vector<GroundType>>;
   using GroundVec = std::vector<std::vector<Ground>>;
 
-  std::string get_texture_name(const GroundTypeVec& v, int x, int y);
-
   TextureStore& mTextureStore;
   GroundVec mGround;
 };

--- a/src/background/BackgroundTextureName.cpp
+++ b/src/background/BackgroundTextureName.cpp
@@ -8,7 +8,9 @@
 using namespace std::string_literals;
 
 std::string BackgroundTextureName::get(const GroundTypeVec& v, int x, int y) {
-  if (v[x][y].mIsRoad) return get_road(v, x, y);
+  if (v[x][y].mIsRoad) {
+    return get_road(v, x, y);
+  }
   return get_surface(v, x, y);
 }
 
@@ -84,24 +86,29 @@ std::string BackgroundTextureName::get_road(const GroundTypeVec& v, int x, int y
 
   if (is_x_crossroad(v, x, y)) {
     return texture_name + one_of("CrossingRound.png"s, "Crossing.png"s);
-  } else if (is_t_crossroad(v, x, y)) {
+  }
+  if (is_t_crossroad(v, x, y)) {
     return texture_name + "SplitS.png"s;
   }
 
   if (me.mSurface == SurfaceType::Sand) {
     if (left && left->mIsRoad && left->mSurface == SurfaceType::Grass) {
       return "tileGrass_road"s + one_of("TransitionE.png"s, "TransitionE_dirt.png"s);
-    } else if (right && right->mIsRoad && right->mSurface == SurfaceType::Grass) {
+    }
+    if (right && right->mIsRoad && right->mSurface == SurfaceType::Grass) {
       return "tileGrass_road"s + one_of("TransitionW.png"s, "TransitionW_dirt.png"s);
-    } else if (up && up->mIsRoad && up->mSurface == SurfaceType::Grass) {
+    }
+    if (up && up->mIsRoad && up->mSurface == SurfaceType::Grass) {
       return "tileGrass_road"s + one_of("TransitionN.png"s, "TransitionN_dirt.png"s);
-    } else if (down && down->mIsRoad && down->mSurface == SurfaceType::Grass) {
+    }
+    if (down && down->mIsRoad && down->mSurface == SurfaceType::Grass) {
       return "tileGrass_road"s + one_of("TransitionS.png"s, "TransitionS_dirt.png"s);
     }
   }
   if (is_vertical_road(v, x, y)) {
     return texture_name + "North.png";
-  } else if (is_horizontal_road(v, x, y)) {
+  }
+  if (is_horizontal_road(v, x, y)) {
     return texture_name + "East.png";
   }
   throw std::runtime_error("Not recognized background pattern");
@@ -111,11 +118,14 @@ std::string BackgroundTextureName::get_surface(const GroundTypeVec& v, int x, in
   if (v[x][y].mSurface == SurfaceType::Sand) {
     if (x - 1 >= 0 && v[x - 1][y].mSurface == SurfaceType::Grass) {
       return "tileGrass_transitionS.png"s;
-    } else if (y - 1 >= 0 && v[x][y - 1].mSurface == SurfaceType::Grass) {
+    }
+    if (y - 1 >= 0 && v[x][y - 1].mSurface == SurfaceType::Grass) {
       return "tileGrass_transitionE.png"s;
-    } else if (x + 1 < FIELDS_HEIGHT && v[x + 1][y].mSurface == SurfaceType::Grass) {
+    }
+    if (x + 1 < FIELDS_HEIGHT && v[x + 1][y].mSurface == SurfaceType::Grass) {
       return "tileGrass_transitionN.png"s;
-    } else if (y + 1 < FIELDS_WIDTH && v[x][y + 1].mSurface == SurfaceType::Grass) {
+    }
+    if (y + 1 < FIELDS_WIDTH && v[x][y + 1].mSurface == SurfaceType::Grass) {
       return "tileGrass_transitionW.png";
     }
     return one_of("tileSand1.png"s, "tileSand2.png"s);

--- a/src/background/Ground.hpp
+++ b/src/background/Ground.hpp
@@ -14,7 +14,7 @@ struct GroundType {
 class Ground {
  public:
   Ground(sf::Texture& texture);
-  void draw(sf::RenderWindow& window, const int x, const int y);
+  void draw(sf::RenderWindow& window, int x, int y);
 
  private:
   sf::Sprite mSprite;

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -54,3 +54,11 @@ inline bool is_sprite_y_in_board(const float y, const sf::Sprite& sp) {
       fabs(sp.getOrigin().y - (sp.getLocalBounds().top + sp.getLocalBounds().height));
   return y > sp_top_y_offset && y < HEIGHT - sp_bot_y_offset;
 }
+
+inline float get_opposite_angle(const float angle) {
+  float opposite_angle = angle - 180.f;
+  if (opposite_angle < 0.f) {
+    opposite_angle = 360.f + opposite_angle;
+  }
+  return opposite_angle;
+}


### PR DESCRIPTION
- Fixed most of the readability warnings issued by clang-tidy (except some magic numbers)
- Removed unnecessary function BackgroundTextureName::get_name()
- Added .clang-tidy config file, where it is possible to specify options to the rules
- Removed modernize-use-trailing-return-type check from 'make tidy' target