### PR TITLE
Change the way clang-tidy is run on CI

### DIFF
--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -92,4 +92,9 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: |
-          cmake --build . --target tidy
+          run-clang-tidy-$CLANG_TIDY_VERSION \ 
+          -clang-tidy-binary clang-tidy-$CLANG_TIDY_VERSION \
+          -header-filter=.* \ 
+          -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type \
+          -p=. \
+          ${{runner.workspace}}/src/ ${{runner.workspace}}/src/background/

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -89,12 +89,11 @@ jobs:
           pkill -9 Xvfb
 
     - name: Clang tidy
-      working-directory: ${{runner.workspace}}/build
       shell: bash
       run: >
           run-clang-tidy-$CLANG_TIDY_VERSION
           -clang-tidy-binary clang-tidy-$CLANG_TIDY_VERSION
           -header-filter=.*
           -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
-          -p=.
+          -p=${{runner.workspace}}/build
           ${{runner.workspace}}/src/* ${{runner.workspace}}/src/background/*

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -94,6 +94,6 @@ jobs:
           run-clang-tidy-$CLANG_TIDY_VERSION
           -clang-tidy-binary clang-tidy-$CLANG_TIDY_VERSION
           -header-filter=.*
-          -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
+          -checks=clang-analyzer-*,bugprone-*,cert-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
           -p=${{runner.workspace}}/build
           ${{runner.workspace}}/src/* ${{runner.workspace}}/src/background/*

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -97,4 +97,4 @@ jobs:
           -header-filter=.*
           -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
           -p=.
-          ${{runner.workspace}}/src/ ${{runner.workspace}}/src/background/
+          ${{runner.workspace}}/src/* ${{runner.workspace}}/src/background/*

--- a/.github/workflows/ubuntu_gcc.yaml
+++ b/.github/workflows/ubuntu_gcc.yaml
@@ -91,10 +91,10 @@ jobs:
     - name: Clang tidy
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: |
-          run-clang-tidy-$CLANG_TIDY_VERSION \ 
-          -clang-tidy-binary clang-tidy-$CLANG_TIDY_VERSION \
-          -header-filter=.* \ 
-          -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type \
-          -p=. \
+      run: >
+          run-clang-tidy-$CLANG_TIDY_VERSION
+          -clang-tidy-binary clang-tidy-$CLANG_TIDY_VERSION
+          -header-filter=.*
+          -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
+          -p=.
           ${{runner.workspace}}/src/ ${{runner.workspace}}/src/background/


### PR DESCRIPTION
There is an error when integrating clang-tidy with CMake (duplicate warnings)