### PR TITLE
Clang tidy refactor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -236,7 +236,7 @@ CheckOptions:
   - key:             modernize-use-equals-default.IgnoreMacros
     value:           'true'
   - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
-    value:           'false'
+    value:           'true'
   - key:             cert-dcl37-c.AggressiveDependentMemberLookup
     value:           'false'
   - key:             modernize-use-emplace.SmartPointers
@@ -390,7 +390,7 @@ CheckOptions:
   - key:             cert-dcl51-cpp.Invert
     value:           'false'
   - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
-    value:           'false'
+    value:           'true'
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
     value:           'true'
   - key:             modernize-make-unique.IgnoreMacros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ find_package(
   COMPONENTS graphics
   REQUIRED)
 find_package(range-v3 REQUIRED)
+find_package(Microsoft.GSL CONFIG REQUIRED)
 
 if(UNIX AND NOT APPLE)
   # workaround for missing opengl dependency in SFML CMake
@@ -67,7 +68,7 @@ if(UNIX AND NOT APPLE)
   set(EXTRA_LIBS GL)
 endif()
 
-target_link_libraries(tank_bot_fight_lib PUBLIC sfml-graphics ${EXTRA_LIBS})
+target_link_libraries(tank_bot_fight_lib PUBLIC sfml-graphics ${EXTRA_LIBS} Microsoft.GSL::GSL)
 target_link_libraries(tank_bot_fight PRIVATE tank_bot_fight_lib sfml-graphics)
 
 add_subdirectory(test)

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -16,7 +16,7 @@ function(add_tidy_target TIDY_VERSION)
     -clang-tidy-binary
     ${CLANG_TIDY_BIN}
     -header-filter=.*
-    -checks=clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-performance-type-promotion-in-math-fn,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,
+    -checks=clang-analyzer-*,bugprone-*,cert-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-performance-type-promotion-in-math-fn,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-modernize-use-nodiscard
     -p=${CMAKE_BINARY_DIR}
     ${add_tidy_target_FILES}
     )

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -16,7 +16,7 @@ function(add_tidy_target TIDY_VERSION)
     -clang-tidy-binary
     ${CLANG_TIDY_BIN}
     -header-filter=.*
-    -checks=clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type
+    -checks=clang-analyzer-*,bugprone-*,cert-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-performance-type-promotion-in-math-fn,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,
     -p=${CMAKE_BINARY_DIR}
     ${add_tidy_target_FILES}
     )

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -33,7 +33,7 @@ void Board::fire_missle(Tank& tank) {
   const auto angle = tank.get_tower_rotation();
   const auto [x, y] = tank.get_position();
   auto& missle_texture = mStore.get_texture("bulletDark3.png");
-  mMissles.emplace_back(missle_texture, angle, x, y);
+  mMissles.emplace_back(missle_texture, MovementState{.mX = x, .mY = y, .mAngle = angle});
   tank.shot();
 }
 
@@ -55,7 +55,7 @@ void Board::run() {
   DummyController dummyController(mTanks[1], *this);
 
   while (mWindow.isOpen()) {
-    sf::Event event;
+    sf::Event event{};
     while (mWindow.pollEvent(event)) {
       if (event.type == sf::Event::Closed) {
         mWindow.close();

--- a/src/Engine.hpp
+++ b/src/Engine.hpp
@@ -5,10 +5,10 @@
 enum class Gear { Drive, Neutral, Reverse };
 class Engine {
  public:
-  virtual void set_gear(const Gear) = 0;
-  virtual float get_current_speed() const = 0;
-  virtual sf::Vector2f get_position_delta(const float rotation_radians) = 0;
+  virtual void set_gear(Gear) = 0;
+  [[nodiscard]] virtual float get_current_speed() const = 0;
+  [[nodiscard]] virtual sf::Vector2f get_position_delta(float rotation_radians) = 0;
   virtual void update() = 0;
-  virtual std::unique_ptr<Engine> copy() const = 0;
+  [[nodiscard]] virtual std::unique_ptr<Engine> copy() const = 0;
   virtual ~Engine() = default;
 };

--- a/src/Files.hpp
+++ b/src/Files.hpp
@@ -3,12 +3,12 @@
 #include <string>
 
 namespace files {
-inline std::string asset_path() {
+[[nodiscard]] inline std::string asset_path() {
   const auto parent_dir_path = std::filesystem::path(__FILE__).parent_path().parent_path().string();
   return parent_dir_path + "/res/";
 }
 
-inline std::string default_size_path() {
+[[nodiscard]] inline std::string default_size_path() {
   const auto parent_dir_path = std::filesystem::path(__FILE__).parent_path().parent_path().string();
   return parent_dir_path + "/res/PNG/Default size/";
 }

--- a/src/Missle.cpp
+++ b/src/Missle.cpp
@@ -2,10 +2,11 @@
 
 #include <SFML/Graphics.hpp>
 #include <cmath>
+#include <gsl/gsl>
 
 #include "Size.hpp"
 
-Missle::Missle(sf::Texture& texture, const int angle, const float x, const float y)
+Missle::Missle(sf::Texture& texture, const float angle, const float x, const float y)
     : mPos({x, y}), mAngle(angle) {
   mSprite.setTexture(texture);
   mSprite.setPosition(mPos.x, mPos.y);
@@ -23,6 +24,6 @@ void Missle::update() {
   const auto rotation_degree = mAngle - 90;
   const auto rotation_radians = PI / 180.f * rotation_degree;
 
-  mPos.x += mSpeed * std::cos(rotation_radians);
-  mPos.y += mSpeed * std::sin(rotation_radians);
+  mPos.x += mSpeed * gsl::narrow_cast<float>(std::cos(rotation_radians));
+  mPos.y += mSpeed * gsl::narrow_cast<float>(std::sin(rotation_radians));
 }

--- a/src/Missle.cpp
+++ b/src/Missle.cpp
@@ -6,11 +6,11 @@
 
 #include "Size.hpp"
 
-Missle::Missle(sf::Texture& texture, const float angle, const float x, const float y)
-    : mPos({x, y}), mAngle(angle) {
+Missle::Missle(sf::Texture& texture, const MovementState& state)
+    : mPos({state.mX, state.mY}), mAngle(state.mAngle) {
   mSprite.setTexture(texture);
   mSprite.setPosition(mPos.x, mPos.y);
-  mSprite.setRotation(angle);
+  mSprite.setRotation(mAngle);
 }
 void Missle::draw(sf::RenderWindow& window) {
   update();

--- a/src/Missle.hpp
+++ b/src/Missle.hpp
@@ -3,7 +3,7 @@
 
 class Missle {
  public:
-  Missle(sf::Texture& texture, const int angle, const float x, const float y);
+  Missle(sf::Texture& texture, float angle, float x, float y);
   void draw(sf::RenderWindow& window);
   void update();
   sf::Vector2f get_pos() const;

--- a/src/Missle.hpp
+++ b/src/Missle.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include <SFML/Graphics.hpp>
 
+#include "MovementState.hpp"
 class Missle {
  public:
-  Missle(sf::Texture& texture, float angle, float x, float y);
+  Missle(sf::Texture& texture, const MovementState& state);
   void draw(sf::RenderWindow& window);
   void update();
-  sf::Vector2f get_pos() const;
+  [[nodiscard]] sf::Vector2f get_pos() const;
 
  private:
   sf::Sprite mSprite;

--- a/src/MovementState.hpp
+++ b/src/MovementState.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+struct MovementState {
+  float mX{};
+  float mY{};
+  float mAngle{};
+};

--- a/src/Obstacle.hpp
+++ b/src/Obstacle.hpp
@@ -6,7 +6,7 @@ class Obstacle {
  public:
   Obstacle(int x, int y);
 
-  sf::Sprite get_sprite();
+  [[nodiscard]] sf::Sprite get_sprite();
 
  private:
   sf::Texture mTxt;

--- a/src/Random.hpp
+++ b/src/Random.hpp
@@ -4,8 +4,8 @@
 [[nodiscard]] int random_range(int begin, int end);
 
 template <typename T, typename... Args>
-T one_of(T first, Args... rest) {
+[[nodiscard]] T one_of(T first, Args... rest) {
   std::array<T, sizeof...(rest) + 1> array = {first, rest...};
 
-  return array.at(random_range(0, sizeof...(rest)));
+  return array[random_range(0, sizeof...(rest))];  // NOLINT
 }

--- a/src/Random.hpp
+++ b/src/Random.hpp
@@ -1,11 +1,11 @@
 #pragma once
-#include <vector>
+#include <array>
 
 int random_range(int begin, int end);
 
 template <typename T, typename... Args>
 T one_of(T first, Args... rest) {
-  T array[sizeof...(rest) + 1] = {first, rest...};
+  std::array<T, sizeof...(rest) + 1> array = {first, rest...};
 
-  return array[random_range(0, sizeof...(rest))];
+  return array.at(random_range(0, sizeof...(rest)));
 }

--- a/src/Random.hpp
+++ b/src/Random.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <array>
 
-int random_range(int begin, int end);
+[[nodiscard]] int random_range(int begin, int end);
 
 template <typename T, typename... Args>
 T one_of(T first, Args... rest) {

--- a/src/SquareRootEngine.cpp
+++ b/src/SquareRootEngine.cpp
@@ -2,16 +2,18 @@
 
 #include <algorithm>
 #include <cmath>
+#include <gsl/gsl>
 #include <stdexcept>
 
 #include "Size.hpp"
 #include "utility.hpp"
 
-SquareRootEngine::SquareRootEngine(const int step_count, const float max_speed)
-    : mStepCount(step_count), mMaxSpeed(max_speed) {}
+SquareRootEngine::SquareRootEngine(const SquareRootEngineConfig& config)
+    : mStepCount(config.mStepCount), mMaxSpeed(config.mMaxSpeed) {}
 
 std::unique_ptr<Engine> SquareRootEngine::copy() const {
-  return std::make_unique<SquareRootEngine>(mStepCount, mMaxSpeed);
+  return std::make_unique<SquareRootEngine>(
+      SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed});
 }
 
 void SquareRootEngine::set_gear(const Gear gear) {
@@ -25,7 +27,7 @@ int SquareRootEngine::get_step_for_current_speed() const {
   if (mCurrentSpeed == 0) {
     return 1;
   }
-  return std::pow(mCurrentSpeed * std::sqrt(mStepCount) / mMaxSpeed, 2);
+  return gsl::narrow_cast<int>(std::pow(mCurrentSpeed * std::sqrt(mStepCount) / mMaxSpeed, 2));
 }
 
 float SquareRootEngine::get_current_speed() const { return mCurrentSpeed; }
@@ -82,13 +84,14 @@ float SquareRootEngine::reduce_abs_speed_by(const float amount) const {
 }
 
 float SquareRootEngine::get_speed_delta() const {
-  return mMaxSpeed * (std::sqrt(mStep) / std::sqrt(mStepCount)) - std::abs(mCurrentSpeed);
+  return mMaxSpeed * gsl::narrow_cast<float>(std::sqrt(mStep) / std::sqrt(mStepCount)) -
+         std::abs(mCurrentSpeed);
 }
 
-float SquareRootEngine::freeride() const { return mMaxSpeed / mStepCount; }
+float SquareRootEngine::freeride() const { return mMaxSpeed / gsl::narrow<float>(mStepCount); }
 
 sf::Vector2f SquareRootEngine::get_position_delta(const float rotation_radians) {
-  mPositionDelta.x = mCurrentSpeed * std::cos(rotation_radians - PI / 2);
-  mPositionDelta.y = mCurrentSpeed * std::sin(rotation_radians - PI / 2);
+  mPositionDelta.x = mCurrentSpeed * gsl::narrow_cast<float>(std::cos(rotation_radians - PI / 2));
+  mPositionDelta.y = mCurrentSpeed * gsl::narrow_cast<float>(std::sin(rotation_radians - PI / 2));
   return mPositionDelta;
 }

--- a/src/SquareRootEngine.hpp
+++ b/src/SquareRootEngine.hpp
@@ -2,9 +2,14 @@
 
 #include "Engine.hpp"
 
+struct SquareRootEngineConfig {
+  int mStepCount{70};
+  float mMaxSpeed{5.f};
+};
+
 class SquareRootEngine : public Engine {
  public:
-  SquareRootEngine(int step_count, float max_speed);
+  explicit SquareRootEngine(const SquareRootEngineConfig& config);
   void set_gear(Gear gear) override;
   [[nodiscard]] float get_current_speed() const override;
   [[nodiscard]] sf::Vector2f get_position_delta(float rotation_radians) override;

--- a/src/SquareRootEngine.hpp
+++ b/src/SquareRootEngine.hpp
@@ -4,13 +4,13 @@
 
 class SquareRootEngine : public Engine {
  public:
-  SquareRootEngine(const int step_count, const float max_speed);
-  void set_gear(const Gear gear) override;
-  float get_current_speed() const override;
-  sf::Vector2f get_position_delta(const float rotation_radians) override;
+  SquareRootEngine(int step_count, float max_speed);
+  void set_gear(Gear gear) override;
+  [[nodiscard]] float get_current_speed() const override;
+  [[nodiscard]] sf::Vector2f get_position_delta(float rotation_radians) override;
   void update() override;
-  std::unique_ptr<Engine> copy() const override;
-  ~SquareRootEngine() = default;
+  [[nodiscard]] std::unique_ptr<Engine> copy() const override;
+  ~SquareRootEngine() override = default;
 
  private:
   float calculate_current_speed() const;
@@ -19,7 +19,7 @@ class SquareRootEngine : public Engine {
   int get_step_for_current_speed() const;
   float get_speed_delta() const;
   float freeride() const;
-  float reduce_abs_speed_by(const float) const;
+  float reduce_abs_speed_by(float amount) const;
 
   Gear mCurrentGear{Gear::Neutral};
   float mCurrentSpeed{};

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -47,7 +47,7 @@ void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
   window.draw(mSprite);
 }
 
-Tank::Tank(float x, float y, TankTextures textures, std::unique_ptr<Engine> &&engine,
+Tank::Tank(float x, float y, const TankTextures& textures, std::unique_ptr<Engine> &&engine,
            const TracesHandlerConfig &traces_handler_config)
     : mPos({x, y}),
       mBody(textures.mBody),

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -47,7 +47,7 @@ void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
   window.draw(mSprite);
 }
 
-Tank::Tank(float x, float y, const TankTextures& textures, std::unique_ptr<Engine> &&engine,
+Tank::Tank(float x, float y, const TankTextures &textures, std::unique_ptr<Engine> &&engine,
            const TracesHandlerConfig &traces_handler_config)
     : mPos({x, y}),
       mBody(textures.mBody),

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -1,6 +1,7 @@
 #include "Tank.hpp"
 
 #include <cmath>
+#include <gsl/gsl>
 
 #include "Size.hpp"
 #include "TextureStore.hpp"
@@ -15,12 +16,12 @@ constexpr std::chrono::milliseconds SHOT_ANIMATION_DURATION = std::chrono::milli
 TankPart::TankPart(sf::Texture &texture) {
   mSprite.setTexture(texture);
   const auto [width, height] = texture.getSize();
-  mSprite.setOrigin(width / 2.f, height / 2.f);
+  mSprite.setOrigin(gsl::narrow<float>(width) / 2.f, gsl::narrow<float>(height) / 2.f);
 }
 
 void TankPart::rotate(const Rotation r) { mRotation = r; }
 
-void TankPart::set_rotation(const int angle) { mSprite.setRotation(angle); }
+void TankPart::set_rotation(const float angle) { mSprite.setRotation(angle); }
 
 float TankPart::get_rotation() const { return mSprite.getRotation(); }
 
@@ -75,7 +76,7 @@ Tank::Tank(const Tank &rhs)
                                                      mBody.get_sprite(), mPos,
                                                      rhs.mTracesHandler->get_config())) {}
 
-Tank::Tank(Tank &&rhs)
+Tank::Tank(Tank &&rhs) noexcept
     : mPos(std::move(rhs.mPos)),
       mCurrentSpeed(std::move(rhs.mCurrentSpeed)),
       mShotStart(std::move(rhs.mShotStart)),
@@ -106,7 +107,7 @@ Tank &Tank::operator=(const Tank &rhs) {
   return *this;
 }
 
-Tank &Tank::operator=(Tank &&rhs) {
+Tank &Tank::operator=(Tank &&rhs) noexcept {
   if (this == &rhs) {
     return *this;
   }
@@ -152,7 +153,8 @@ void Tank::update() {
 }
 
 void Tank::update_position() {
-  const auto &delta = mEngine->get_position_delta(to_radians(mBody.get_rotation()));
+  const auto &delta =
+      mEngine->get_position_delta(gsl::narrow_cast<float>(to_radians(mBody.get_rotation())));
   const auto new_pos = mPos + delta;
   if (is_sprite_x_in_board(new_pos.x, mBody.get_sprite())) {
     mPos.x = new_pos.x;

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -47,15 +47,14 @@ void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
   window.draw(mSprite);
 }
 
-Tank::Tank(float x, float y, sf::Texture &body, sf::Texture &tower, sf::Texture &shot,
-           sf::Texture &tracks, std::unique_ptr<Engine> &&engine,
+Tank::Tank(float x, float y, TankTextures textures, std::unique_ptr<Engine> &&engine,
            const TracesHandlerConfig &traces_handler_config)
     : mPos({x, y}),
-      mBody(body),
-      mTower(tower),
-      mShot(shot),
+      mBody(textures.mBody),
+      mTower(textures.mTower),
+      mShot(textures.mShot),
       mEngine(std::move(engine)),
-      mTracesHandler(std::make_unique<TracesHandler>(tracks, mBody.get_sprite(), mPos,
+      mTracesHandler(std::make_unique<TracesHandler>(textures.mTracks, mBody.get_sprite(), mPos,
                                                      traces_handler_config)) {
   set_rotation(TANK_INITIAL_ROTATION);
   mBody.get_sprite().setPosition(mPos);
@@ -77,10 +76,10 @@ Tank::Tank(const Tank &rhs)
                                                      rhs.mTracesHandler->get_config())) {}
 
 Tank::Tank(Tank &&rhs) noexcept
-    : mPos(std::move(rhs.mPos)),
-      mCurrentSpeed(std::move(rhs.mCurrentSpeed)),
-      mShotStart(std::move(rhs.mShotStart)),
-      mDrawShot(std::move(rhs.mDrawShot)),
+    : mPos(rhs.mPos),
+      mCurrentSpeed(rhs.mCurrentSpeed),
+      mShotStart(rhs.mShotStart),
+      mDrawShot(rhs.mDrawShot),
       mBody(std::move(rhs.mBody)),
       mTower(std::move(rhs.mTower)),
       mShot(std::move(rhs.mShot)),
@@ -111,10 +110,10 @@ Tank &Tank::operator=(Tank &&rhs) noexcept {
   if (this == &rhs) {
     return *this;
   }
-  mPos = std::move(rhs.mPos);
-  mCurrentSpeed = std::move(rhs.mCurrentSpeed);
-  mShotStart = std::move(rhs.mShotStart);
-  mDrawShot = std::move(rhs.mDrawShot);
+  mPos = rhs.mPos;
+  mCurrentSpeed = rhs.mCurrentSpeed;
+  mShotStart = rhs.mShotStart;
+  mDrawShot = rhs.mDrawShot;
   mBody = std::move(rhs.mBody);
   mTower = std::move(rhs.mTower);
   mShot = std::move(rhs.mShot);
@@ -134,7 +133,7 @@ void Tank::rotate_tower(Rotation r) {
   mShot.rotate(r);
 }
 
-void Tank::set_rotation(const int angle) {
+void Tank::set_rotation(const float angle) {
   mTower.set_rotation(angle);
   mBody.set_rotation(angle);
   mShot.set_rotation(angle);

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -38,7 +38,7 @@ struct TankTextures {
 
 class Tank {
  public:
-  Tank(float x, float y, TankTextures textures, std::unique_ptr<Engine>&& engine,
+  Tank(float x, float y, const TankTextures& textures, std::unique_ptr<Engine>&& engine,
        const TracesHandlerConfig& traces_handler_config = TracesHandlerConfig{});
   Tank(const Tank& rhs);
   Tank(Tank&& rhs) noexcept;

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -15,9 +15,9 @@ class TankPart {
  public:
   explicit TankPart(sf::Texture& texture);
 
-  void rotate(const Rotation r);
-  void set_rotation(const int angle);
-  void draw(sf::RenderWindow& window, const float x, const float y);
+  void rotate(Rotation r);
+  void set_rotation(float angle);
+  void draw(sf::RenderWindow& window, float x, float y);
   float get_rotation() const;
   sf::Sprite& get_sprite();
   const sf::Sprite& get_sprite() const;
@@ -33,18 +33,18 @@ class Tank {
   Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
        sf::Texture& tracks, std::unique_ptr<Engine>&& engine,
        const TracesHandlerConfig& traces_handler_config = TracesHandlerConfig{});
-  Tank(const Tank&);
-  Tank(Tank&&);
-  Tank& operator=(const Tank&);
-  Tank& operator=(Tank&&);
+  Tank(const Tank& rhs);
+  Tank(Tank&& rhs) noexcept;
+  Tank& operator=(const Tank& rhs);
+  Tank& operator=(Tank&& rhs) noexcept;
   ~Tank() = default;
 
   void rotate_body(Rotation r);
   void rotate_tower(Rotation r);
-  void set_rotation(const int angle);
+  void set_rotation(int angle);
 
   void set_gear(Gear gear);
-  void draw(sf::RenderWindow&);
+  void draw(sf::RenderWindow& window);
   void update();
   void shot();
 
@@ -56,8 +56,8 @@ class Tank {
   inline constexpr static float M_SPEED = 0.01f;
   void update_shot();
   void update_position();
-  void draw_shot(sf::RenderWindow&);
-  void draw_tracks(sf::RenderWindow&);
+  void draw_shot(sf::RenderWindow& window);
+  void draw_tracks(sf::RenderWindow& window);
 
   sf::Vector2f mPos;
   float mCurrentSpeed = 0.0f;

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -3,6 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <chrono>
+#include <functional>
 #include <memory>
 
 #include "Engine.hpp"
@@ -28,10 +29,16 @@ class TankPart {
   Rotation mRotation = Rotation::None;
 };
 
+struct TankTextures {
+  std::reference_wrapper<sf::Texture> mBody;
+  std::reference_wrapper<sf::Texture> mTower;
+  std::reference_wrapper<sf::Texture> mShot;
+  std::reference_wrapper<sf::Texture> mTracks;
+};
+
 class Tank {
  public:
-  Tank(float x, float y, sf::Texture& body, sf::Texture& tower, sf::Texture& shot,
-       sf::Texture& tracks, std::unique_ptr<Engine>&& engine,
+  Tank(float x, float y, TankTextures textures, std::unique_ptr<Engine>&& engine,
        const TracesHandlerConfig& traces_handler_config = TracesHandlerConfig{});
   Tank(const Tank& rhs);
   Tank(Tank&& rhs) noexcept;
@@ -41,16 +48,16 @@ class Tank {
 
   void rotate_body(Rotation r);
   void rotate_tower(Rotation r);
-  void set_rotation(int angle);
+  void set_rotation(float angle);
 
   void set_gear(Gear gear);
   void draw(sf::RenderWindow& window);
   void update();
   void shot();
 
-  float get_tower_rotation() const;
-  sf::Vector2f get_position();
-  float get_current_speed();
+  [[nodiscard]] float get_tower_rotation() const;
+  [[nodiscard]] sf::Vector2f get_position();
+  [[nodiscard]] float get_current_speed();
 
  private:
   inline constexpr static float M_SPEED = 0.01f;

--- a/src/TankFactory.cpp
+++ b/src/TankFactory.cpp
@@ -6,8 +6,6 @@
 Tank TankFactory::Random(TextureStore& store, float x, float y) {
   using namespace std::string_literals;
   const sf::IntRect TRACKS_TEXTURE_RECT = {0, 0, 37, 48};
-  constexpr int STEP_COUNT = 70;
-  constexpr float MAX_SPEED = 5.f;
   auto& body_texture = store.get_texture(one_of("tankBody_red.png"s, "tankBody_dark.png"s,
                                                 "tankBody_blue.png"s, "tankBody_green.png"s));
   body_texture.setSmooth(true);
@@ -20,7 +18,12 @@ Tank TankFactory::Random(TextureStore& store, float x, float y) {
   auto& tracks_texture = store.get_texture("tracksSmall.png", TRACKS_TEXTURE_RECT);
   tracks_texture.setSmooth(true);
   tracks_texture.setRepeated(true);
-  return Tank(x, y, body_texture, tower_texture, shot_texture, tracks_texture,
-              std::make_unique<SquareRootEngine>(STEP_COUNT, MAX_SPEED),
-              TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f});
+  return {x, y,
+          TankTextures{.mBody = body_texture,
+                       .mTower = tower_texture,
+                       .mShot = shot_texture,
+                       .mTracks = tracks_texture},
+          std::make_unique<SquareRootEngine>(
+              SquareRootEngineConfig{.mStepCount = 70, .mMaxSpeed = 5.f}),
+          TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f}};
 }

--- a/src/TankFactory.hpp
+++ b/src/TankFactory.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <Tank.hpp>
-#include <TextureStore.hpp>
 
+class TextureStore;
 class TankFactory {
  public:
-  static Tank Random(TextureStore& store, float x, float y);
+  [[nodiscard]] static Tank Random(TextureStore& store, float x, float y);
 };

--- a/src/TextureStore.hpp
+++ b/src/TextureStore.hpp
@@ -12,7 +12,7 @@ class TextureStore {
   TextureStore& operator=(TextureStore&&) = delete;
   ~TextureStore() = default;
 
-  sf::Texture& get_texture(const std::string& path, const sf::IntRect& = sf::IntRect{});
+  sf::Texture& get_texture(const std::string& path, const sf::IntRect& area = sf::IntRect{});
 
  private:
   std::unordered_map<std::string, sf::Texture> mStore;

--- a/src/TextureStore.hpp
+++ b/src/TextureStore.hpp
@@ -12,7 +12,8 @@ class TextureStore {
   TextureStore& operator=(TextureStore&&) = delete;
   ~TextureStore() = default;
 
-  sf::Texture& get_texture(const std::string& path, const sf::IntRect& area = sf::IntRect{});
+  [[nodiscard]] sf::Texture& get_texture(const std::string& path,
+                                         const sf::IntRect& area = sf::IntRect{});
 
  private:
   std::unordered_map<std::string, sf::Texture> mStore;

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -1,14 +1,14 @@
 #include "Trace.hpp"
 
 #include <cmath>
+#include <gsl/gsl>
 
-Trace::Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
-             const float start_height)
-    : mTexture(tex), mRotation(angle) {
-  const float width = mTexture.getSize().x;
+Trace::Trace(const sf::Texture& tex, const MovementState& state, const float start_height)
+    : mTexture(tex), mRotation(state.mAngle) {
+  const auto width = gsl::narrow<float>(mTexture.getSize().x);
   const auto origin = sf::Vector2f{width / 2, 0.f};
-  mTransform.translate(-origin).translate(pos);
-  mTransform.rotate(angle, origin);
+  mTransform.translate(-origin).translate(state.mX, state.mY);
+  mTransform.rotate(state.mAngle, origin);
 
   mVertices[0].position = {0.f, 0.f};
   mVertices[0].texCoords = {0.f, 0.f};

--- a/src/Trace.hpp
+++ b/src/Trace.hpp
@@ -1,5 +1,5 @@
+#include "MovementState.hpp"
 #include "SFML/Graphics.hpp"
-
 class Trace : public sf::Drawable {
   sf::Transform mTransform;
   sf::VertexArray mVertices{sf::Quads, 4};
@@ -9,7 +9,7 @@ class Trace : public sf::Drawable {
   void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
  public:
-  Trace(const sf::Texture& tex, const sf::Vector2f& pos, float angle, float start_height);
+  Trace(const sf::Texture& tex, const MovementState& state, float start_height);
   void increase_height(float amount);
   void decrease_height(float amount);
   [[nodiscard]] float get_height() const;

--- a/src/Trace.hpp
+++ b/src/Trace.hpp
@@ -9,10 +9,9 @@ class Trace : public sf::Drawable {
   void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
  public:
-  Trace(const sf::Texture& tex, const sf::Vector2f& pos, const float angle,
-        const float start_height);
-  void increase_height(const float amount);
-  void decrease_height(const float amount);
-  float get_height() const;
-  float get_rotation() const;
+  Trace(const sf::Texture& tex, const sf::Vector2f& pos, float angle, float start_height);
+  void increase_height(float amount);
+  void decrease_height(float amount);
+  [[nodiscard]] float get_height() const;
+  [[nodiscard]] float get_rotation() const;
 };

--- a/src/TracesHandler.cpp
+++ b/src/TracesHandler.cpp
@@ -1,5 +1,7 @@
 #include "TracesHandler.hpp"
 
+#include <gsl/gsl>
+
 #include "utility.hpp"
 
 sf::Vector2f get_middle_top_transform(const sf::Sprite& sprite,
@@ -20,7 +22,7 @@ TracesHandler::TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite,
     : mTracksTexture(tracks),
       mTankSprite(tank_sprite),
       mLastTankPos(start_pos),
-      mMaxTextureHeight(mTracksTexture.getSize().y),
+      mMaxTextureHeight(gsl::narrow<int>(mTracksTexture.getSize().y)),
       mConfig(config) {}
 
 TracesHandler::TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite,
@@ -64,7 +66,7 @@ void TracesHandler::decay_traces() {
   }
   if (mTracesAge.front() >= mConfig.mMaxTraceAge) {
     const float trace_height = mTraces.front().get_height();
-    const float decrease_by = mConfig.mDecayRate * mMaxTextureHeight;
+    const float decrease_by = mConfig.mDecayRate * gsl::narrow<float>(mMaxTextureHeight);
     if (trace_height <= decrease_by) {
       remove_trace();
       return;
@@ -97,7 +99,7 @@ Trace TracesHandler::make_trace(const sf::Vector2f& move) const {
   } else {
     pos = get_middle_top_transform(mTankSprite, -move_distance);
   }
-  return Trace(mTracksTexture, pos, angle, move_distance);
+  return {mTracksTexture, MovementState{.mX = pos.x, .mY = pos.y, .mAngle = angle}, move_distance};
 }
 
 bool TracesHandler::is_moving_forward(const sf::Vector2f& move) const {

--- a/src/TracesHandler.hpp
+++ b/src/TracesHandler.hpp
@@ -21,25 +21,25 @@ class TracesHandler {
 
   void update_traces_age();
   void decay_traces();
-  void add_trace(const Trace&);
+  void add_trace(const Trace& trace);
   void remove_trace();
   bool is_move_angle_changed(const sf::Vector2f& move) const;
   Trace make_trace(const sf::Vector2f& move) const;
-  bool is_moving_forward(const sf::Vector2f&) const;
+  bool is_moving_forward(const sf::Vector2f& move) const;
 
  public:
   TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite, const sf::Vector2f& start_pos,
-                const int max_trace_age, const float decay_rate);
+                int max_trace_age, float decay_rate);
   TracesHandler(const sf::Texture& tracks, sf::Sprite& tank_sprite, const sf::Vector2f& start_pos,
                 const TracesHandlerConfig& config = TracesHandlerConfig{});
   TracesHandler(const TracesHandler&) = delete;
-  TracesHandler(TracesHandler&&) = delete;
+  TracesHandler(TracesHandler&&) noexcept = delete;
   TracesHandler& operator=(const TracesHandler&) = delete;
-  TracesHandler& operator=(TracesHandler&&) = delete;
+  TracesHandler& operator=(TracesHandler&&) noexcept = delete;
   ~TracesHandler() = default;
 
-  const std::deque<Trace>& get_traces() const;
-  const sf::Texture& get_trace_texture() const;
-  TracesHandlerConfig get_config() const;
+  [[nodiscard]] const std::deque<Trace>& get_traces() const;
+  [[nodiscard]] const sf::Texture& get_trace_texture() const;
+  [[nodiscard]] TracesHandlerConfig get_config() const;
   void update();
 };

--- a/src/background/Background.hpp
+++ b/src/background/Background.hpp
@@ -8,7 +8,7 @@
 
 class Background {
  public:
-  Background(TextureStore& texture_store);
+  explicit Background(TextureStore& texture_store);
 
   void draw(sf::RenderWindow& mWindow);
 

--- a/src/background/Ground.hpp
+++ b/src/background/Ground.hpp
@@ -13,7 +13,7 @@ struct GroundType {
 
 class Ground {
  public:
-  Ground(sf::Texture& texture);
+  explicit Ground(sf::Texture& texture);
   void draw(sf::RenderWindow& window, int x, int y);
 
  private:

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -2,6 +2,7 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <cmath>
+#include <gsl/gsl>
 #include <iostream>
 
 #include "Size.hpp"
@@ -34,7 +35,7 @@ inline float get_angle(const sf::Vector2f& vec) {
   if (equal(vec.x, 0.f) && equal(vec.y, 0.f)) {
     return 0.f;
   }
-  auto degrees = to_degrees(atan2(vec.y, vec.x)) + 90;
+  auto degrees = gsl::narrow_cast<float>(to_degrees(atan2(vec.y, vec.x))) + 90;
   if (degrees < 0) {
     return 360 + degrees;
   }
@@ -42,15 +43,15 @@ inline float get_angle(const sf::Vector2f& vec) {
 }
 
 inline bool is_sprite_x_in_board(const float x, const sf::Sprite& sp) {
-  const float sp_left_x_offset = fabs(sp.getOrigin().x - sp.getLocalBounds().left);
-  const float sp_right_x_offset =
+  const auto sp_left_x_offset = fabs(sp.getOrigin().x - sp.getLocalBounds().left);
+  const auto sp_right_x_offset =
       fabs(sp.getOrigin().x - (sp.getLocalBounds().left + sp.getLocalBounds().width));
   return x > sp_left_x_offset && x < WIDTH - sp_right_x_offset;
 }
 
 inline bool is_sprite_y_in_board(const float y, const sf::Sprite& sp) {
-  const float sp_top_y_offset = fabs(sp.getOrigin().y - sp.getLocalBounds().top);
-  const float sp_bot_y_offset =
+  const auto sp_top_y_offset = fabs(sp.getOrigin().y - sp.getLocalBounds().top);
+  const auto sp_bot_y_offset =
       fabs(sp.getOrigin().y - (sp.getLocalBounds().top + sp.getLocalBounds().height));
   return y > sp_top_y_offset && y < HEIGHT - sp_bot_y_offset;
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -7,16 +7,19 @@
 
 #include "Size.hpp"
 
-constexpr inline double to_radians(double degrees) { return PI / 180.f * degrees; }
-constexpr inline double to_degrees(double radians) { return radians / PI * 180; }
-inline sf::Vector2f fabs(const sf::Vector2f& vec) { return {std::fabs(vec.x), std::fabs(vec.y)}; }
-inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
+[[nodiscard]] constexpr inline double to_radians(double degrees) { return PI / 180.f * degrees; }
+[[nodiscard]] constexpr inline double to_degrees(double radians) { return radians / PI * 180; }
+[[nodiscard]] inline sf::Vector2f fabs(const sf::Vector2f& vec) {
+  return {std::fabs(vec.x), std::fabs(vec.y)};
+}
+[[nodiscard]] inline float hypot(const sf::Vector2f& vec) { return std::hypot(vec.x, vec.y); }
 
-inline bool equal(float lhs, float rhs, float precision = 0.001f) {
+[[nodiscard]] inline bool equal(float lhs, float rhs, float precision = 0.001f) {
   return std::fabs(lhs - rhs) < precision;
 }
 
-inline bool equal(const sf::Vector2f& lhs, const sf::Vector2f& rhs, float precision = 0.001f) {
+[[nodiscard]] inline bool equal(const sf::Vector2f& lhs, const sf::Vector2f& rhs,
+                                float precision = 0.001f) {
   return equal(lhs.x, rhs.x, precision) && equal(lhs.y, rhs.y, precision);
 }
 
@@ -31,8 +34,8 @@ inline void print_point(const auto& point) {
   std::cout << "(x, y): (" << x << ", " << y << ")\n";
 }
 
-inline float get_angle(const sf::Vector2f& vec) {
-  if (equal(vec.x, 0.f) && equal(vec.y, 0.f)) {
+[[nodiscard]] inline float get_angle(const sf::Vector2f& vec) {
+  if (equal(vec, {0.f, 0.f})) {
     return 0.f;
   }
   auto degrees = gsl::narrow_cast<float>(to_degrees(atan2(vec.y, vec.x))) + 90;
@@ -42,21 +45,21 @@ inline float get_angle(const sf::Vector2f& vec) {
   return degrees;
 }
 
-inline bool is_sprite_x_in_board(const float x, const sf::Sprite& sp) {
+[[nodiscard]] inline bool is_sprite_x_in_board(const float x, const sf::Sprite& sp) {
   const auto sp_left_x_offset = fabs(sp.getOrigin().x - sp.getLocalBounds().left);
   const auto sp_right_x_offset =
       fabs(sp.getOrigin().x - (sp.getLocalBounds().left + sp.getLocalBounds().width));
   return x > sp_left_x_offset && x < WIDTH - sp_right_x_offset;
 }
 
-inline bool is_sprite_y_in_board(const float y, const sf::Sprite& sp) {
+[[nodiscard]] inline bool is_sprite_y_in_board(const float y, const sf::Sprite& sp) {
   const auto sp_top_y_offset = fabs(sp.getOrigin().y - sp.getLocalBounds().top);
   const auto sp_bot_y_offset =
       fabs(sp.getOrigin().y - (sp.getLocalBounds().top + sp.getLocalBounds().height));
   return y > sp_top_y_offset && y < HEIGHT - sp_bot_y_offset;
 }
 
-inline float get_opposite_angle(const float angle) {
+[[nodiscard]] inline float get_opposite_angle(const float angle) {
   float opposite_angle = angle - 180.f;
   if (opposite_angle < 0.f) {
     opposite_angle = 360.f + opposite_angle;

--- a/test/SquareRootEngineTests.cpp
+++ b/test/SquareRootEngineTests.cpp
@@ -18,7 +18,8 @@ struct SquareRootEngineTest : ::testing::Test {
   float mSpeed{1.f};
   float mZero{0.f};
   float mAngle{0.f};
-  SquareRootEngine mEngineSUT{mStepCount, mMaxSpeed};
+  SquareRootEngine mEngineSUT{
+      SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
 
   void assert_speed_delta(const auto expected_speed_delta, const int count) {
     for (int i : ranges::iota_view(0, count)) {
@@ -80,7 +81,8 @@ TEST_F(SquareRootEngineTest,
   mStepCount = 2;
   mMaxSpeed = 1;
   const float expected_speed = 0.7071f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
 
   mEngineSUT.update();
@@ -91,7 +93,8 @@ TEST_F(SquareRootEngineTest,
 TEST_F(SquareRootEngineTest,
        Given3StepCountAnd3UpdatesAndDriveGearThenGetCurrentSpeedShouldReturnMaxSpeed) {
   mStepCount = 3;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
 
   update_many(mEngineSUT, mStepCount);
@@ -104,7 +107,8 @@ TEST_F(SquareRootEngineTest,
   mStepCount = 5;
   mMaxSpeed = 3.f;
   const float expected_speed = 1.3416f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
 
   mEngineSUT.update();
@@ -117,7 +121,8 @@ TEST_F(SquareRootEngineTest,
   mStepCount = 5;
   mMaxSpeed = 3.f;
   const float expected_speed = 1.8973f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
 
   update_many(mEngineSUT, 2);
@@ -127,7 +132,8 @@ TEST_F(SquareRootEngineTest,
 
 TEST_F(SquareRootEngineTest, GivenTankMovingForwardWhenGearSetToNeutralThenSpeedShouldDecrease) {
   mStepCount = 2;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   mEngineSUT.update();
   const auto speed_before = mEngineSUT.get_current_speed();
@@ -141,7 +147,8 @@ TEST_F(SquareRootEngineTest, GivenTankMovingForwardWhenGearSetToNeutralThenSpeed
 
 TEST_F(SquareRootEngineTest, GivenTankMovingBackwardWhenGearSetToNeutralThenSpeedShouldIncrease) {
   mStepCount = 2;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Reverse);
   mEngineSUT.update();
   const auto speed_before = mEngineSUT.get_current_speed();
@@ -156,7 +163,8 @@ TEST_F(SquareRootEngineTest, GivenTankMovingBackwardWhenGearSetToNeutralThenSpee
 TEST_F(SquareRootEngineTest,
        Given2StepCountAndMaxSpeedWhenGearSetToNeutralAnd2UpdatesThenGetCurrentSpeedShouldReturn0) {
   mStepCount = 2;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   update_many(mEngineSUT, mStepCount);
 
@@ -170,7 +178,8 @@ TEST_F(
     SquareRootEngineTest,
     Given2StepCountAndNegativeMaxSpeedWhenGearSetToNeutralAnd2UpdatesThenGetCurrentSpeedShouldReturn0) {
   mStepCount = 2;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Reverse);
   update_many(mEngineSUT, mStepCount);
 
@@ -186,7 +195,8 @@ TEST_F(
   mStepCount = 10;
   mMaxSpeed = 10;
   const auto expected_speed_delta = -1.f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   update_many(mEngineSUT, mStepCount);
 
@@ -201,7 +211,8 @@ TEST_F(
   mStepCount = 10;
   mMaxSpeed = 10;
   const auto expected_speed_delta = 1.f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Reverse);
   update_many(mEngineSUT, mStepCount);
 
@@ -216,7 +227,8 @@ TEST_F(
   mStepCount = 5;
   mMaxSpeed = 10;
   const auto expected_speed_delta = -2.f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   update_many(mEngineSUT, mStepCount);
 
@@ -230,7 +242,8 @@ TEST_F(
     GivenDriveGearMaxSpeed3AndStepCount5And3UpdatesWhenGearSetToNeutralAnd4UpdatesThenGetCurrentSpeedShouldReturn0) {
   mStepCount = 5;
   mMaxSpeed = 3;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   update_many(mEngineSUT, 3);
 
@@ -245,7 +258,8 @@ TEST_F(
     GivenReverseGearMaxSpeed3AndStepCount5And3UpdatesWhenGearSetToNeutralAnd4UpdatesThenGetCurrentSpeedShouldReturn0) {
   mStepCount = 5;
   mMaxSpeed = 3;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Reverse);
   update_many(mEngineSUT, 3);
 
@@ -261,7 +275,8 @@ TEST_F(
   mStepCount = 10;
   mMaxSpeed = 10;
   const auto expected_speed_delta = -3.f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
   update_many(mEngineSUT, mStepCount);
   mEngineSUT.set_gear(Gear::Reverse);
@@ -278,7 +293,8 @@ TEST_F(
   mStepCount = 10;
   mMaxSpeed = 10;
   const auto expected_speed_delta = 3.f;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Reverse);
   update_many(mEngineSUT, mStepCount);
   mEngineSUT.set_gear(Gear::Drive);
@@ -358,7 +374,8 @@ TEST_F(SquareRootEngineTest, GivenDynamicSpeedThenGetPositionDeltaShouldOnlyRetu
   mStepCount = 2;
   mMaxSpeed = 1;
   mAngle = PI / 2;
-  mEngineSUT = SquareRootEngine(mStepCount, mMaxSpeed);
+  mEngineSUT =
+      SquareRootEngine{SquareRootEngineConfig{.mStepCount = mStepCount, .mMaxSpeed = mMaxSpeed}};
   mEngineSUT.set_gear(Gear::Drive);
 
   mEngineSUT.update();

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -33,13 +33,15 @@ struct TankTest : ::testing::Test {
   int mAngle{90};
 
   Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
-    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine),
-                TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f});
+    return {0, 0,
+            TankTextures{.mBody = *mBody, .mTower = *mTower, .mShot = *mShot, .mTracks = *mTracks},
+            std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
   }
 
   Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
-    return Tank(0, 0, *mBody, *mTower, *mShot, *mTracks, std::move(engine),
-                TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f});
+    return {0, 0,
+            TankTextures{.mBody = *mBody, .mTower = *mTower, .mShot = *mShot, .mTracks = *mTracks},
+            std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
   }
 };
 

--- a/test/UtilityTests.cpp
+++ b/test/UtilityTests.cpp
@@ -46,7 +46,7 @@ INSTANTIATE_TEST_CASE_P(
                           330.f}));
 
 TEST(GetAngleTest, GetAngleShouldComplementGetPositionDelta) {
-  SquareRootEngine engine(1, 2);
+  SquareRootEngine engine{SquareRootEngineConfig{.mStepCount = 1, .mMaxSpeed = 2.f}};
   float expected_angle_radians = PI / 4;
   engine.set_gear(Gear::Drive);
   engine.update();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "builtin-baseline": "50fd3d9957195575849a49fa591e645f1d8e7156",
   "dependencies": [
     "sfml",
+    "ms-gsl",
     {
        "name": "range-v3",
        "version>=": "2021-11-02"


### PR DESCRIPTION
As for now, there are no clang-tidy warnings for our project, however the PR is quite large (sorry).

- added GSL library (guidelines support library)
- removed some of the checks that were adding too much noise:
  - modernize-use-nodiscard check, it produced too much noise, and using [[nodiscard]] everywhere is too much according to me
  - readability-magic-numbers check, it didn't work with non-const class members and designated initializers
  - performance-type-promotion-in-math-fn, doesn't really matter to us
  - cppcoreguidelines-pro-type-union-access, we are forced to use `sf::Event` union because of SFML
- removed duplicate clang-analyzer-* check
- added `[[nodiscard]]` to all public functions that return values in our system (I am not quite sure where should it be used, do you have any ideas?)
- created `MovementState` struct to contain position and angle (these were passed as seperate arguments to both `Missle` and `Trace`; now they are passed as a single struct)
- created `SquareRootEngineConfig` to contain similar type arguments into a single struct
- created `TankTextures` struct to contain all `sf::Textures` used in `Tank` (to avoid confusing argument order by mistake)

- using `gsl::narrow_cast` to indicate that it is fine to narrow the result
- using `gsl::narrow` to indicate that the result should not be narrowed, although the resulting type is smaller by definition