### PR TITLE
Missiles destroy tanks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ set(CLANG_TIDY_VERSION
 
 if(ENABLE_CLANG_TIDY)
   add_tidy_target(
-    ${CLANG_TIDY_VERSION} FILES ${CMAKE_SOURCE_DIR}/src/*
-    ${CMAKE_SOURCE_DIR}/src/background/* ${CMAKE_SOURCE_DIR}/src/Controllers/*
-    ${CMAKE_SOURCE_DIR}/src/Tank/*)
+    ${CLANG_TIDY_VERSION}
+    FILES
+    ${CMAKE_SOURCE_DIR}/src/*
+    ${CMAKE_SOURCE_DIR}/src/background/*
+    ${CMAKE_SOURCE_DIR}/src/Controllers/*
+    ${CMAKE_SOURCE_DIR}/src/Tank/*
+    ${CMAKE_SOURCE_DIR}/src/Players/*)
 endif()
 
 add_library(
@@ -43,7 +47,9 @@ add_library(
   src/Random.cpp
   src/SquareRootEngine.cpp
   src/TracesHandler.cpp
-  src/Trace.cpp)
+  src/Trace.cpp
+  src/Players/DummyPlayer.cpp
+  src/Players/KeyboardPlayer.cpp)
 
 target_include_directories(tank_bot_fight_lib PRIVATE src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,10 @@ set(CLANG_TIDY_VERSION
     CACHE STRING "Clang tidy version to run checks")
 
 if(ENABLE_CLANG_TIDY)
-  add_tidy_target(${CLANG_TIDY_VERSION} FILES ${CMAKE_SOURCE_DIR}/src/*
-                  ${CMAKE_SOURCE_DIR}/src/background/* ${CMAKE_SOURCE_DIR}/src/Controllers/*)
+  add_tidy_target(
+    ${CLANG_TIDY_VERSION} FILES ${CMAKE_SOURCE_DIR}/src/*
+    ${CMAKE_SOURCE_DIR}/src/background/* ${CMAKE_SOURCE_DIR}/src/Controllers/*
+    ${CMAKE_SOURCE_DIR}/src/Tank/*)
 endif()
 
 add_library(
@@ -70,7 +72,8 @@ if(UNIX AND NOT APPLE)
   set(EXTRA_LIBS GL)
 endif()
 
-target_link_libraries(tank_bot_fight_lib PUBLIC sfml-graphics ${EXTRA_LIBS} Microsoft.GSL::GSL)
+target_link_libraries(tank_bot_fight_lib PUBLIC sfml-graphics ${EXTRA_LIBS}
+                                                Microsoft.GSL::GSL)
 target_link_libraries(tank_bot_fight PRIVATE tank_bot_fight_lib sfml-graphics)
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ add_library(
   src/Controllers/KeyboardController.cpp
   src/Controllers/DummyController.cpp
   src/Missle.cpp
-  src/Tank.cpp
-  src/TankFactory.cpp
+  src/Tank/Tank.cpp
+  src/Tank/TankFactory.cpp
+  src/Tank/TankPart.cpp
+  src/Tank/TankTower.cpp
   src/TextureStore.cpp
   src/Obstacle.cpp
   src/Random.cpp

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -23,8 +23,8 @@ void Board::register_tank() {
   constexpr float TANK2_X = WIDTH / 2.0f;
   constexpr float TANK2_Y = 400.0f;
 
-  mTanks.emplace_back(TankFactory::Random(mStore, TANK_X, TANK_Y));
-  mTanks.emplace_back(TankFactory::Random(mStore, TANK2_X, TANK2_Y));
+  mTanks.emplace_back(std::make_shared<Tank>(TankFactory::Random(mStore, TANK_X, TANK_Y)));
+  mTanks.emplace_back(std::make_shared<Tank>(TankFactory::Random(mStore, TANK2_X, TANK2_Y)));
   mFont.loadFromFile(files::asset_path() + "DejaVuSans.ttf");
   mText.setFont(mFont);
 }
@@ -40,8 +40,8 @@ void Board::fire_missle(Tank& tank) {
 void Board::draw() {
   mWindow.clear();
   mBackground.draw(mWindow);
-  for (auto& tank : mTanks) {
-    tank.draw(mWindow);
+  for (const auto& tank : mTanks) {
+    tank->draw(mWindow);
   }
   for (auto& missle : mMissles) {
     missle.draw(mWindow);
@@ -67,17 +67,21 @@ void Board::run() {
       keyboard_controller.update(event);
     }
 
-    for (auto& tank : mTanks) {
-      tank.update();
+    for (const auto& tank : mTanks) {
+      tank->update();
     }
     dummyController.update();
     draw();
     remove_missles();
+    remove_tanks();
   }
 }
 
 void Board::display_speed() {
-  mText.setString(std::to_string(mTanks[0].get_current_speed()));
+  if (mTanks.empty()) {
+    return;
+  }
+  mText.setString(std::to_string(mTanks[0]->get_current_speed()));
   mWindow.draw(mText);
 }
 
@@ -85,5 +89,15 @@ void Board::remove_missles() {
   std::erase_if(mMissles, [](const auto& missle) -> bool {
     const auto [x, y] = missle.get_pos();
     return (x > WIDTH || y > HEIGHT || x < 0 || y < 0);
+  });
+}
+
+// tanks gets shot by themselves!
+// there must be a way to decide whether the missle was shot by a particular tank...
+void Board::remove_tanks() {
+  std::erase_if(mTanks, [this](const auto& tank) {
+    const auto& body = tank->get_body_rect();
+    return std::any_of(mMissles.cbegin(), mMissles.cend(),
+                       [&body](const auto& missle) { return body.contains(missle.get_pos()); });
   });
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -8,7 +8,7 @@
 #include "Random.hpp"
 #include "Size.hpp"
 #include "SquareRootEngine.hpp"
-#include "TankFactory.hpp"
+#include "Tank/TankFactory.hpp"
 #include "TracesHandler.hpp"
 
 Board::Board() : mWindow(sf::VideoMode(WIDTH, HEIGHT), "TankBotFight"), mBackground(mStore) {
@@ -29,13 +29,7 @@ void Board::register_tank() {
   mText.setFont(mFont);
 }
 
-void Board::fire_missle(Tank& tank) {
-  const auto angle = tank.get_tower_rotation();
-  const auto [x, y] = tank.get_position();
-  auto& missle_texture = mStore.get_texture("bulletDark3.png");
-  mMissles.emplace_back(missle_texture, MovementState{.mX = x, .mY = y, .mAngle = angle});
-  tank.shot();
-}
+void Board::register_missile(const Missle& missile) { mMissles.push_back(missile); }
 
 void Board::draw() {
   mWindow.clear();
@@ -93,11 +87,12 @@ void Board::remove_missles() {
 }
 
 // tanks gets shot by themselves!
-// there must be a way to decide whether the missle was shot by a particular tank...
+// there must be a way to decide whether the missle was shot by a particular tank... - NO! tanks
+// should never be able to catch up with the missle they shot missiles must be faster
 void Board::remove_tanks() {
   std::erase_if(mTanks, [this](const auto& tank) {
     const auto& body = tank->get_body_rect();
     return std::any_of(mMissles.cbegin(), mMissles.cend(),
-                       [&body](const auto& missle) { return body.contains(missle.get_pos()); });
+                       [&body](const auto& missile) { return body.contains(missile.get_pos()); });
   });
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -86,13 +86,22 @@ void Board::remove_missles() {
   });
 }
 
-// tanks gets shot by themselves!
-// there must be a way to decide whether the missle was shot by a particular tank... - NO! tanks
-// should never be able to catch up with the missle they shot missiles must be faster
 void Board::remove_tanks() {
-  std::erase_if(mTanks, [this](const auto& tank) {
+  std::vector<Missle> missiles_collided{};
+
+  std::erase_if(mTanks, [this, &missiles_collided](const auto& tank) {
     const auto& body = tank->get_body_rect();
-    return std::any_of(mMissles.cbegin(), mMissles.cend(),
-                       [&body](const auto& missile) { return body.contains(missile.get_pos()); });
+    const auto missile =
+        std::find_if(mMissles.cbegin(), mMissles.cend(),
+                     [&body](const auto& missile) { return body.contains(missile.get_pos()); });
+    if (missile != mMissles.cend()) {
+      missiles_collided.push_back(*missile);
+    }
+    return missile != mMissles.cend();
+  });
+
+  std::erase_if(mMissles, [&missiles_collided](const auto& missile) {
+    return std::any_of(missiles_collided.cbegin(), missiles_collided.cend(),
+                       [&missile](const auto& m) { return m == missile; });
   });
 }

--- a/src/Board.hpp
+++ b/src/Board.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <memory>
 
 #include "Missle.hpp"
 #include "Tank.hpp"
@@ -17,13 +18,14 @@ class Board {
 
  private:
   void remove_missles();
+  void remove_tanks();
   void display_speed();
   void draw();
 
   TextureStore mStore;
   sf::RenderWindow mWindow;
   Background mBackground;
-  std::vector<Tank> mTanks;
+  std::vector<std::shared_ptr<Tank>> mTanks;
   std::vector<Missle> mMissles;
   sf::Font mFont;
   sf::Text mText;

--- a/src/Board.hpp
+++ b/src/Board.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "Missle.hpp"
-#include "Tank.hpp"
+#include "Tank/Tank.hpp"
 #include "background/Background.hpp"
 
 class Board {
@@ -12,7 +12,7 @@ class Board {
   Board();
 
   void register_tank();
-  void fire_missle(Tank& tank);
+  void register_missile(const Missle& missile);
 
   void run();
 

--- a/src/Board.hpp
+++ b/src/Board.hpp
@@ -4,28 +4,28 @@
 #include <memory>
 
 #include "Missle.hpp"
-#include "Tank/Tank.hpp"
+#include "Players/DummyPlayer.hpp"
+#include "Players/KeyboardPlayer.hpp"
 #include "background/Background.hpp"
 
 class Board {
  public:
   Board();
 
-  void register_tank();
   void register_missile(const Missle& missile);
-
   void run();
 
  private:
   void remove_missles();
-  void remove_tanks();
+  void remove_players();
   void display_speed();
   void draw();
 
   TextureStore mStore;
   sf::RenderWindow mWindow;
   Background mBackground;
-  std::vector<std::shared_ptr<Tank>> mTanks;
+  std::unique_ptr<KeyboardPlayer> mKeyboardPlayer;
+  std::unique_ptr<DummyPlayer> mDummyPlayer;
   std::vector<Missle> mMissles;
   sf::Font mFont;
   sf::Text mText;

--- a/src/Controllers/DummyController.cpp
+++ b/src/Controllers/DummyController.cpp
@@ -2,18 +2,14 @@
 
 #include <Board.hpp>
 #include <Random.hpp>
+#include <Tank/Tank.hpp>
 #include <iostream>
 
-DummyController::DummyController(const std::shared_ptr<Tank> &tank, Board &board)
-    : mTank(tank), mBoard(board) {
+DummyController::DummyController(Tank &tank, Board &board) : mTank(tank), mBoard(board) {
   mLastChange = std::chrono::system_clock::now();
 }
 
 void DummyController::update() {
-  if (mTank.expired()) {
-    return;
-  }
-  const auto &tank = mTank.lock();
   const auto now = std::chrono::system_clock::now();
   const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastChange);
 
@@ -26,23 +22,23 @@ void DummyController::update() {
 
   switch (mCurrentMove) {
     case DummyMove::Shot:
-      if (const auto &missile = tank->shoot()) {
+      if (const auto &missile = mTank.shoot()) {
         mBoard.register_missile(missile.value());
       }
       break;
     case DummyMove::Forward:
-      tank->set_gear(Gear::Drive);
+      mTank.set_gear(Gear::Drive);
       break;
     case DummyMove::TurnLeft:
-      tank->rotate_body(Rotation::Clockwise);
-      tank->rotate_tower(Rotation::Clockwise);
+      mTank.rotate_body(Rotation::Clockwise);
+      mTank.rotate_tower(Rotation::Clockwise);
       break;
     case DummyMove::TurnRight:
-      tank->rotate_body(Rotation::Counterclockwise);
-      tank->rotate_tower(Rotation::Counterclockwise);
+      mTank.rotate_body(Rotation::Counterclockwise);
+      mTank.rotate_tower(Rotation::Counterclockwise);
       break;
     case DummyMove::Idle:
-      tank->set_gear(Gear::Neutral);
+      mTank.set_gear(Gear::Neutral);
       break;
     default:
       break;

--- a/src/Controllers/DummyController.cpp
+++ b/src/Controllers/DummyController.cpp
@@ -5,11 +5,16 @@
 #include <Tank.hpp>
 #include <iostream>
 
-DummyController::DummyController(Tank &tank, Board &board) : mTank(tank), mBoard(board) {
+DummyController::DummyController(const std::shared_ptr<Tank> &tank, Board &board)
+    : mTank(tank), mBoard(board) {
   mLastChange = std::chrono::system_clock::now();
 }
 
 void DummyController::update() {
+  if (mTank.expired()) {
+    return;
+  }
+  const auto &tank = mTank.lock();
   const auto now = std::chrono::system_clock::now();
   const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastChange);
 
@@ -22,21 +27,21 @@ void DummyController::update() {
 
   switch (mCurrentMove) {
     case DummyMove::Shot:
-      mBoard.fire_missle(mTank);
+      mBoard.fire_missle(*tank);
       break;
     case DummyMove::Forward:
-      mTank.set_gear(Gear::Drive);
+      tank->set_gear(Gear::Drive);
       break;
     case DummyMove::TurnLeft:
-      mTank.rotate_body(Rotation::Clockwise);
-      mTank.rotate_tower(Rotation::Clockwise);
+      tank->rotate_body(Rotation::Clockwise);
+      tank->rotate_tower(Rotation::Clockwise);
       break;
     case DummyMove::TurnRight:
-      mTank.rotate_body(Rotation::Counterclockwise);
-      mTank.rotate_tower(Rotation::Counterclockwise);
+      tank->rotate_body(Rotation::Counterclockwise);
+      tank->rotate_tower(Rotation::Counterclockwise);
       break;
     case DummyMove::Idle:
-      mTank.set_gear(Gear::Neutral);
+      tank->set_gear(Gear::Neutral);
       break;
     default:
       break;

--- a/src/Controllers/DummyController.cpp
+++ b/src/Controllers/DummyController.cpp
@@ -26,7 +26,7 @@ void DummyController::update() {
 
   switch (mCurrentMove) {
     case DummyMove::Shot:
-      if (const auto &missile = tank->shot()) {
+      if (const auto &missile = tank->shoot()) {
         mBoard.register_missile(missile.value());
       }
       break;

--- a/src/Controllers/DummyController.cpp
+++ b/src/Controllers/DummyController.cpp
@@ -2,7 +2,6 @@
 
 #include <Board.hpp>
 #include <Random.hpp>
-#include <Tank.hpp>
 #include <iostream>
 
 DummyController::DummyController(const std::shared_ptr<Tank> &tank, Board &board)
@@ -27,7 +26,9 @@ void DummyController::update() {
 
   switch (mCurrentMove) {
     case DummyMove::Shot:
-      mBoard.fire_missle(*tank);
+      if (const auto &missile = tank->shot()) {
+        mBoard.register_missile(missile.value());
+      }
       break;
     case DummyMove::Forward:
       tank->set_gear(Gear::Drive);

--- a/src/Controllers/DummyController.hpp
+++ b/src/Controllers/DummyController.hpp
@@ -2,7 +2,7 @@
 #include <chrono>
 #include <memory>
 
-#include "Tank.hpp"
+#include "Tank/Tank.hpp"
 
 class Board;
 

--- a/src/Controllers/DummyController.hpp
+++ b/src/Controllers/DummyController.hpp
@@ -1,10 +1,8 @@
 #pragma once
 #include <chrono>
-#include <memory>
-
-#include "Tank/Tank.hpp"
 
 class Board;
+class Tank;
 
 enum class DummyMove {
   Forward,
@@ -16,11 +14,11 @@ enum class DummyMove {
 
 class DummyController {
  public:
-  DummyController(const std::shared_ptr<Tank>& tank, Board& board);
+  DummyController(Tank& tank, Board& board);
   void update();
 
  private:
-  std::weak_ptr<Tank> mTank;
+  Tank& mTank;
   Board& mBoard;
   DummyMove mCurrentMove = DummyMove::Idle;
   std::chrono::time_point<std::chrono::system_clock> mLastChange;

--- a/src/Controllers/DummyController.hpp
+++ b/src/Controllers/DummyController.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <chrono>
+#include <memory>
 
-class Tank;
+#include "Tank.hpp"
+
 class Board;
 
 enum class DummyMove {
@@ -14,11 +16,11 @@ enum class DummyMove {
 
 class DummyController {
  public:
-  DummyController(Tank& tank, Board& board);
+  DummyController(const std::shared_ptr<Tank>& tank, Board& board);
   void update();
 
  private:
-  Tank& mTank;
+  std::weak_ptr<Tank> mTank;
   Board& mBoard;
   DummyMove mCurrentMove = DummyMove::Idle;
   std::chrono::time_point<std::chrono::system_clock> mLastChange;

--- a/src/Controllers/KeyboardController.cpp
+++ b/src/Controllers/KeyboardController.cpp
@@ -34,7 +34,7 @@ void KeyboardController::update(const sf::Event& event) {
         tank->set_gear(Gear::Reverse);
         break;
       case sf::Keyboard::Space:
-        if (const auto& missile = tank->shot()) {
+        if (const auto& missile = tank->shoot()) {
           mBoard.register_missile(missile.value());
         }
         break;

--- a/src/Controllers/KeyboardController.cpp
+++ b/src/Controllers/KeyboardController.cpp
@@ -5,36 +5,31 @@
 #include "Board.hpp"
 #include "Engine.hpp"
 
-KeyboardController::KeyboardController(const std::shared_ptr<Tank>& tank, Board& board)
-    : mTank(tank), mBoard(board) {}
+KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {}
 
 void KeyboardController::update(const sf::Event& event) {
-  if (mTank.expired()) {
-    return;
-  }
-  const auto& tank = mTank.lock();
   if (event.type == sf::Event::KeyPressed) {
     switch (event.key.code) {
       case sf::Keyboard::A:
-        tank->rotate_body(Rotation::Counterclockwise);
+        mTank.rotate_body(Rotation::Counterclockwise);
         break;
       case sf::Keyboard::D:
-        tank->rotate_body(Rotation::Clockwise);
+        mTank.rotate_body(Rotation::Clockwise);
         break;
       case sf::Keyboard::Left:
-        tank->rotate_tower(Rotation::Counterclockwise);
+        mTank.rotate_tower(Rotation::Counterclockwise);
         break;
       case sf::Keyboard::Right:
-        tank->rotate_tower(Rotation::Clockwise);
+        mTank.rotate_tower(Rotation::Clockwise);
         break;
       case sf::Keyboard::W:
-        tank->set_gear(Gear::Drive);
+        mTank.set_gear(Gear::Drive);
         break;
       case sf::Keyboard::S:
-        tank->set_gear(Gear::Reverse);
+        mTank.set_gear(Gear::Reverse);
         break;
       case sf::Keyboard::Space:
-        if (const auto& missile = tank->shoot()) {
+        if (const auto& missile = mTank.shoot()) {
           mBoard.register_missile(missile.value());
         }
         break;
@@ -46,15 +41,15 @@ void KeyboardController::update(const sf::Event& event) {
     switch (event.key.code) {
       case sf::Keyboard::A:
       case sf::Keyboard::D:
-        tank->rotate_body(Rotation::None);
+        mTank.rotate_body(Rotation::None);
         break;
       case sf::Keyboard::Left:
       case sf::Keyboard::Right:
-        tank->rotate_tower(Rotation::None);
+        mTank.rotate_tower(Rotation::None);
         break;
       case sf::Keyboard::W:
       case sf::Keyboard::S:
-        tank->set_gear(Gear::Neutral);
+        mTank.set_gear(Gear::Neutral);
         break;
       default:
         break;

--- a/src/Controllers/KeyboardController.cpp
+++ b/src/Controllers/KeyboardController.cpp
@@ -6,18 +6,7 @@
 #include "Engine.hpp"
 
 KeyboardController::KeyboardController(const std::shared_ptr<Tank>& tank, Board& board)
-    : mTank(tank), mBoard(board) {
-  mLastShot = std::chrono::system_clock::now();
-}
-
-void KeyboardController::handle_shot(const std::shared_ptr<Tank>& tank) {
-  const auto& missile =
-      tank->shot();  // it would control: cooldown, animation [draw function], in case cooldown is
-                     // right it would return missile with the right parameters
-  if (missile) {
-    mBoard.register_missile(missile.value());
-  }
-}
+    : mTank(tank), mBoard(board) {}
 
 void KeyboardController::update(const sf::Event& event) {
   if (mTank.expired()) {
@@ -45,7 +34,9 @@ void KeyboardController::update(const sf::Event& event) {
         tank->set_gear(Gear::Reverse);
         break;
       case sf::Keyboard::Space:
-        handle_shot(tank);
+        if (const auto& missile = tank->shot()) {
+          mBoard.register_missile(missile.value());
+        }
         break;
       default:
         break;

--- a/src/Controllers/KeyboardController.cpp
+++ b/src/Controllers/KeyboardController.cpp
@@ -4,42 +4,49 @@
 
 #include "Board.hpp"
 #include "Engine.hpp"
-#include "Tank.hpp"
 
-KeyboardController::KeyboardController(Tank& tank, Board& board) : mTank(tank), mBoard(board) {
+KeyboardController::KeyboardController(const std::shared_ptr<Tank>& tank, Board& board)
+    : mTank(tank), mBoard(board) {
   mLastShot = std::chrono::system_clock::now();
 }
 
 void KeyboardController::handle_shot() {
+  if (mTank.expired()) {
+    return;
+  }
   const auto now = std::chrono::system_clock::now();
   const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
   constexpr auto SHOT_COOLDOWN = std::chrono::milliseconds{500};
   if (elapsed >= SHOT_COOLDOWN) {
     mLastShot = now;
-    mBoard.fire_missle(mTank);
+    mBoard.fire_missle(*mTank.lock());
   }
 }
 
 void KeyboardController::update(const sf::Event& event) {
+  if (mTank.expired()) {
+    return;
+  }
+  const auto& tank = mTank.lock();
   if (event.type == sf::Event::KeyPressed) {
     switch (event.key.code) {
       case sf::Keyboard::A:
-        mTank.rotate_body(Rotation::Counterclockwise);
+        tank->rotate_body(Rotation::Counterclockwise);
         break;
       case sf::Keyboard::D:
-        mTank.rotate_body(Rotation::Clockwise);
+        tank->rotate_body(Rotation::Clockwise);
         break;
       case sf::Keyboard::Left:
-        mTank.rotate_tower(Rotation::Counterclockwise);
+        tank->rotate_tower(Rotation::Counterclockwise);
         break;
       case sf::Keyboard::Right:
-        mTank.rotate_tower(Rotation::Clockwise);
+        tank->rotate_tower(Rotation::Clockwise);
         break;
       case sf::Keyboard::W:
-        mTank.set_gear(Gear::Drive);
+        tank->set_gear(Gear::Drive);
         break;
       case sf::Keyboard::S:
-        mTank.set_gear(Gear::Reverse);
+        tank->set_gear(Gear::Reverse);
         break;
       case sf::Keyboard::Space:
         handle_shot();
@@ -52,15 +59,15 @@ void KeyboardController::update(const sf::Event& event) {
     switch (event.key.code) {
       case sf::Keyboard::A:
       case sf::Keyboard::D:
-        mTank.rotate_body(Rotation::None);
+        tank->rotate_body(Rotation::None);
         break;
       case sf::Keyboard::Left:
       case sf::Keyboard::Right:
-        mTank.rotate_tower(Rotation::None);
+        tank->rotate_tower(Rotation::None);
         break;
       case sf::Keyboard::W:
       case sf::Keyboard::S:
-        mTank.set_gear(Gear::Neutral);
+        tank->set_gear(Gear::Neutral);
         break;
       default:
         break;

--- a/src/Controllers/KeyboardController.cpp
+++ b/src/Controllers/KeyboardController.cpp
@@ -10,16 +10,12 @@ KeyboardController::KeyboardController(const std::shared_ptr<Tank>& tank, Board&
   mLastShot = std::chrono::system_clock::now();
 }
 
-void KeyboardController::handle_shot() {
-  if (mTank.expired()) {
-    return;
-  }
-  const auto now = std::chrono::system_clock::now();
-  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
-  constexpr auto SHOT_COOLDOWN = std::chrono::milliseconds{500};
-  if (elapsed >= SHOT_COOLDOWN) {
-    mLastShot = now;
-    mBoard.fire_missle(*mTank.lock());
+void KeyboardController::handle_shot(const std::shared_ptr<Tank>& tank) {
+  const auto& missile =
+      tank->shot();  // it would control: cooldown, animation [draw function], in case cooldown is
+                     // right it would return missile with the right parameters
+  if (missile) {
+    mBoard.register_missile(missile.value());
   }
 }
 
@@ -49,7 +45,7 @@ void KeyboardController::update(const sf::Event& event) {
         tank->set_gear(Gear::Reverse);
         break;
       case sf::Keyboard::Space:
-        handle_shot();
+        handle_shot(tank);
         break;
       default:
         break;

--- a/src/Controllers/KeyboardController.hpp
+++ b/src/Controllers/KeyboardController.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <chrono>
+#include <memory>
 
-class Tank;
+#include "Tank.hpp"
+
 class Board;
 namespace sf {
 class Event;
@@ -9,12 +11,12 @@ class Event;
 
 class KeyboardController {
  public:
-  KeyboardController(Tank& tank, Board& board);
+  KeyboardController(const std::shared_ptr<Tank>& tank, Board& board);
   void update(const sf::Event& event);
 
  private:
   void handle_shot();
-  Tank& mTank;
+  std::weak_ptr<Tank> mTank;
   Board& mBoard;
   std::chrono::time_point<std::chrono::system_clock> mLastShot;
 };

--- a/src/Controllers/KeyboardController.hpp
+++ b/src/Controllers/KeyboardController.hpp
@@ -2,7 +2,7 @@
 #include <chrono>
 #include <memory>
 
-#include "Tank.hpp"
+#include "Tank/Tank.hpp"
 
 class Board;
 namespace sf {
@@ -15,7 +15,7 @@ class KeyboardController {
   void update(const sf::Event& event);
 
  private:
-  void handle_shot();
+  void handle_shot(const std::shared_ptr<Tank>& tank);
   std::weak_ptr<Tank> mTank;
   Board& mBoard;
   std::chrono::time_point<std::chrono::system_clock> mLastShot;

--- a/src/Controllers/KeyboardController.hpp
+++ b/src/Controllers/KeyboardController.hpp
@@ -15,8 +15,6 @@ class KeyboardController {
   void update(const sf::Event& event);
 
  private:
-  void handle_shot(const std::shared_ptr<Tank>& tank);
   std::weak_ptr<Tank> mTank;
   Board& mBoard;
-  std::chrono::time_point<std::chrono::system_clock> mLastShot;
 };

--- a/src/Controllers/KeyboardController.hpp
+++ b/src/Controllers/KeyboardController.hpp
@@ -1,20 +1,17 @@
 #pragma once
-#include <chrono>
-#include <memory>
-
-#include "Tank/Tank.hpp"
 
 class Board;
+class Tank;
 namespace sf {
 class Event;
 }
 
 class KeyboardController {
  public:
-  KeyboardController(const std::shared_ptr<Tank>& tank, Board& board);
+  KeyboardController(Tank& tank, Board& board);
   void update(const sf::Event& event);
 
  private:
-  std::weak_ptr<Tank> mTank;
+  Tank& mTank;
   Board& mBoard;
 };

--- a/src/Missle.cpp
+++ b/src/Missle.cpp
@@ -5,6 +5,7 @@
 #include <gsl/gsl>
 
 #include "Size.hpp"
+#include "utility.hpp"
 
 Missle::Missle(sf::Texture& texture, const MovementState& state)
     : mPos({state.mX, state.mY}), mAngle(state.mAngle) {
@@ -27,3 +28,5 @@ void Missle::update() {
   mPos.x += mSpeed * gsl::narrow_cast<float>(std::cos(rotation_radians));
   mPos.y += mSpeed * gsl::narrow_cast<float>(std::sin(rotation_radians));
 }
+
+bool Missle::operator==(const Missle& rhs) const { return equal(mPos, rhs.get_pos()); }

--- a/src/Missle.hpp
+++ b/src/Missle.hpp
@@ -9,6 +9,8 @@ class Missle {
   void update();
   [[nodiscard]] sf::Vector2f get_pos() const;
 
+  bool operator==(const Missle& rhs) const;
+
  private:
   sf::Sprite mSprite;
   float mSpeed = 20.0f;

--- a/src/Players/DummyPlayer.cpp
+++ b/src/Players/DummyPlayer.cpp
@@ -1,0 +1,17 @@
+#include "DummyPlayer.hpp"
+
+#include "SFML/Graphics.hpp"
+
+DummyPlayer::DummyPlayer(Board& board, std::unique_ptr<Tank>&& tank)
+    : mBoard(board),
+      mTank(std::move(tank)),
+      mController(std::make_unique<DummyController>(*mTank, mBoard)) {}
+
+void DummyPlayer::draw(sf::RenderWindow& window) { mTank->draw(window); }
+
+void DummyPlayer::update() {
+  mController->update();
+  mTank->update();
+}
+
+const Tank& DummyPlayer::get_tank() const { return *mTank; }

--- a/src/Players/DummyPlayer.hpp
+++ b/src/Players/DummyPlayer.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+#include "Controllers/DummyController.hpp"
+#include "Tank/Tank.hpp"
+
+namespace sf {
+class Event;
+class RenderWindow;
+}  // namespace sf
+
+class Board;
+
+class DummyPlayer {
+ public:
+  DummyPlayer(Board& board, std::unique_ptr<Tank>&& tank);
+
+  void draw(sf::RenderWindow& window);
+  void update();
+
+  [[nodiscard]] const Tank& get_tank() const;
+
+ private:
+  Board& mBoard;
+  std::unique_ptr<Tank> mTank;
+  std::unique_ptr<DummyController> mController;
+};

--- a/src/Players/KeyboardPlayer.cpp
+++ b/src/Players/KeyboardPlayer.cpp
@@ -1,0 +1,16 @@
+#include "KeyboardPlayer.hpp"
+
+#include "SFML/Graphics.hpp"
+
+KeyboardPlayer::KeyboardPlayer(Board& board, std::unique_ptr<Tank>&& tank)
+    : mBoard(board),
+      mTank(std::move(tank)),
+      mController(std::make_unique<KeyboardController>(*mTank, mBoard)) {}
+
+void KeyboardPlayer::draw(sf::RenderWindow& window) { mTank->draw(window); }
+
+void KeyboardPlayer::handle_events(const sf::Event& event) { mController->update(event); }
+
+void KeyboardPlayer::update() { mTank->update(); }
+
+const Tank& KeyboardPlayer::get_tank() const { return *mTank; }

--- a/src/Players/KeyboardPlayer.hpp
+++ b/src/Players/KeyboardPlayer.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+
+#include "Controllers/KeyboardController.hpp"
+#include "Tank/Tank.hpp"
+
+namespace sf {
+class Event;
+class RenderWindow;
+}  // namespace sf
+
+class Board;
+
+class KeyboardPlayer {
+ public:
+  KeyboardPlayer(Board& board, std::unique_ptr<Tank>&& tank);
+
+  void draw(sf::RenderWindow& window);
+  void handle_events(const sf::Event& event);
+  void update();
+
+  [[nodiscard]] const Tank& get_tank() const;
+
+ private:
+  Board& mBoard;
+  std::unique_ptr<Tank> mTank;
+  std::unique_ptr<KeyboardController> mController;
+};

--- a/src/Tank.cpp
+++ b/src/Tank.cpp
@@ -141,6 +141,8 @@ void Tank::set_rotation(const float angle) {
 
 sf::Vector2f Tank::get_position() { return mPos; }
 
+sf::FloatRect Tank::get_body_rect() const { return mBody.get_sprite().getGlobalBounds(); }
+
 void Tank::update() {
   mBody.update();
   mTower.update();

--- a/src/Tank.hpp
+++ b/src/Tank.hpp
@@ -57,6 +57,7 @@ class Tank {
 
   [[nodiscard]] float get_tower_rotation() const;
   [[nodiscard]] sf::Vector2f get_position();
+  [[nodiscard]] sf::FloatRect get_body_rect() const;
   [[nodiscard]] float get_current_speed();
 
  private:

--- a/src/Tank/Tank.cpp
+++ b/src/Tank/Tank.cpp
@@ -113,7 +113,7 @@ void Tank::update_position() {
   mTower.set_position(mPos);
 }
 
-std::optional<Missle> Tank::shot() { return mTower.shot(); }
+std::optional<Missle> Tank::shoot() { return mTower.shoot(); }
 
 float Tank::get_current_speed() { return mEngine->get_current_speed(); }
 

--- a/src/Tank/Tank.cpp
+++ b/src/Tank/Tank.cpp
@@ -8,68 +8,29 @@
 #include "utility.hpp"
 
 constexpr int TANK_INITIAL_ROTATION = 180;
-constexpr int ROTATION_OFFSET = 90;
-constexpr int TANK_PART_ROTATE = 10;
-constexpr int SHOT_ANIMATION_DISTANCE = 30;
-constexpr std::chrono::milliseconds SHOT_ANIMATION_DURATION = std::chrono::milliseconds(100);
-
-TankPart::TankPart(sf::Texture &texture) {
-  mSprite.setTexture(texture);
-  const auto [width, height] = texture.getSize();
-  mSprite.setOrigin(gsl::narrow<float>(width) / 2.f, gsl::narrow<float>(height) / 2.f);
-}
-
-void TankPart::rotate(const Rotation r) { mRotation = r; }
-
-void TankPart::set_rotation(const float angle) { mSprite.setRotation(angle); }
-
-float TankPart::get_rotation() const { return mSprite.getRotation(); }
-
-sf::Sprite &TankPart::get_sprite() { return mSprite; }
-
-const sf::Sprite &TankPart::get_sprite() const { return mSprite; }
-
-void TankPart::update() {
-  switch (mRotation) {
-    case Rotation::Clockwise:
-      mSprite.rotate(TANK_PART_ROTATE);
-      break;
-    case Rotation::Counterclockwise:
-      mSprite.rotate(-TANK_PART_ROTATE);
-      break;
-    case Rotation::None:
-      break;
-  }
-}
-
-void TankPart::draw(sf::RenderWindow &window, const float x, const float y) {
-  mSprite.setPosition(x, y);
-  window.draw(mSprite);
-}
 
 Tank::Tank(float x, float y, const TankTextures &textures, std::unique_ptr<Engine> &&engine,
-           const TracesHandlerConfig &traces_handler_config)
+           const TracesHandlerConfig &traces_handler_config,
+           const std::chrono::milliseconds &shot_cooldown)
     : mPos({x, y}),
       mBody(textures.mBody),
-      mTower(textures.mTower),
-      mShot(textures.mShot),
+      mTower(TankTowerTextures{.mTower = textures.mTower,
+                               .mShotAnimation = textures.mShot,
+                               .mMissile = textures.mMissile},
+             shot_cooldown),
       mEngine(std::move(engine)),
       mTracesHandler(std::make_unique<TracesHandler>(textures.mTracks, mBody.get_sprite(), mPos,
                                                      traces_handler_config)) {
   set_rotation(TANK_INITIAL_ROTATION);
   mBody.get_sprite().setPosition(mPos);
-  mTower.get_sprite().setPosition(mPos);
-  mShot.get_sprite().setPosition(mPos);
+  mTower.set_position(mPos);
 }
 
 Tank::Tank(const Tank &rhs)
     : mPos(rhs.mPos),
       mCurrentSpeed(rhs.mCurrentSpeed),
-      mShotStart(rhs.mShotStart),
-      mDrawShot(rhs.mDrawShot),
       mBody(rhs.mBody),
       mTower(rhs.mTower),
-      mShot(rhs.mShot),
       mEngine(rhs.mEngine->copy()),
       mTracesHandler(std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(),
                                                      mBody.get_sprite(), mPos,
@@ -78,11 +39,8 @@ Tank::Tank(const Tank &rhs)
 Tank::Tank(Tank &&rhs) noexcept
     : mPos(rhs.mPos),
       mCurrentSpeed(rhs.mCurrentSpeed),
-      mShotStart(rhs.mShotStart),
-      mDrawShot(rhs.mDrawShot),
       mBody(std::move(rhs.mBody)),
       mTower(std::move(rhs.mTower)),
-      mShot(std::move(rhs.mShot)),
       mEngine(std::move(rhs.mEngine)),
       mTracesHandler(std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(),
                                                      mBody.get_sprite(), mPos,
@@ -94,11 +52,8 @@ Tank &Tank::operator=(const Tank &rhs) {
   }
   mPos = rhs.mPos;
   mCurrentSpeed = rhs.mCurrentSpeed;
-  mShotStart = rhs.mShotStart;
-  mDrawShot = rhs.mDrawShot;
   mBody = rhs.mBody;
   mTower = rhs.mTower;
-  mShot = rhs.mShot;
   mEngine = rhs.mEngine->copy();
   mTracesHandler =
       std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(),
@@ -112,11 +67,8 @@ Tank &Tank::operator=(Tank &&rhs) noexcept {
   }
   mPos = rhs.mPos;
   mCurrentSpeed = rhs.mCurrentSpeed;
-  mShotStart = rhs.mShotStart;
-  mDrawShot = rhs.mDrawShot;
   mBody = std::move(rhs.mBody);
   mTower = std::move(rhs.mTower);
-  mShot = std::move(rhs.mShot);
   mEngine = std::move(rhs.mEngine);
   mTracesHandler =
       std::make_unique<TracesHandler>(rhs.mTracesHandler->get_trace_texture(), mBody.get_sprite(),
@@ -128,15 +80,11 @@ void Tank::set_gear(Gear gear) { mEngine->set_gear(gear); }
 
 void Tank::rotate_body(Rotation r) { mBody.rotate(r); }
 
-void Tank::rotate_tower(Rotation r) {
-  mTower.rotate(r);
-  mShot.rotate(r);
-}
+void Tank::rotate_tower(Rotation r) { mTower.rotate(r); }
 
 void Tank::set_rotation(const float angle) {
   mTower.set_rotation(angle);
   mBody.set_rotation(angle);
-  mShot.set_rotation(angle);
 }
 
 sf::Vector2f Tank::get_position() { return mPos; }
@@ -146,11 +94,9 @@ sf::FloatRect Tank::get_body_rect() const { return mBody.get_sprite().getGlobalB
 void Tank::update() {
   mBody.update();
   mTower.update();
-  mShot.update();
   mEngine->update();
   update_position();
   mTracesHandler->update();
-  update_shot();
 }
 
 void Tank::update_position() {
@@ -164,46 +110,19 @@ void Tank::update_position() {
     mPos.y = new_pos.y;
   }
   mBody.get_sprite().setPosition(mPos);
-  mTower.get_sprite().setPosition(mPos);
-  mShot.get_sprite().setPosition(mPos);
+  mTower.set_position(mPos);
 }
 
-void Tank::update_shot() {
-  auto now = std::chrono::system_clock::now();
-  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mShotStart);
-  if (elapsed > SHOT_ANIMATION_DURATION) {
-    mDrawShot = false;
-  }
-}
+std::optional<Missle> Tank::shot() { return mTower.shot(); }
 
 float Tank::get_current_speed() { return mEngine->get_current_speed(); }
-
-void Tank::shot() {
-  mShotStart = std::chrono::system_clock::now();
-  mDrawShot = true;
-}
 
 float Tank::get_tower_rotation() const { return mTower.get_rotation(); }
 
 void Tank::draw(sf::RenderWindow &window) {
-  mBody.draw(window, mPos.x, mPos.y);
-  mTower.draw(window, mPos.x, mPos.y);
-  if (mDrawShot) {
-    draw_shot(window);
-  }
+  mBody.draw(window);
+  mTower.draw(window);
   draw_tracks(window);
-}
-
-void Tank::draw_shot(sf::RenderWindow &window) {
-  auto get_shot_animation_pos = [x = mPos.x, y = mPos.y](float tower_rotation) {
-    return sf::Vector2f{
-        x + SHOT_ANIMATION_DISTANCE *
-                static_cast<float>(cos(to_radians(tower_rotation - ROTATION_OFFSET))),
-        y + SHOT_ANIMATION_DISTANCE *
-                static_cast<float>(sin(to_radians(tower_rotation - ROTATION_OFFSET)))};
-  };
-  const auto shot_animation_pos = get_shot_animation_pos(mTower.get_rotation());
-  mShot.draw(window, shot_animation_pos.x, shot_animation_pos.y);
 }
 
 void Tank::draw_tracks(sf::RenderWindow &window) {

--- a/src/Tank/Tank.cpp
+++ b/src/Tank/Tank.cpp
@@ -4,7 +4,6 @@
 #include <gsl/gsl>
 
 #include "Size.hpp"
-#include "TextureStore.hpp"
 #include "utility.hpp"
 
 constexpr int TANK_INITIAL_ROTATION = 180;
@@ -87,7 +86,7 @@ void Tank::set_rotation(const float angle) {
   mBody.set_rotation(angle);
 }
 
-sf::Vector2f Tank::get_position() { return mPos; }
+sf::Vector2f Tank::get_position() const { return mPos; }
 
 sf::FloatRect Tank::get_body_rect() const { return mBody.get_sprite().getGlobalBounds(); }
 
@@ -115,7 +114,7 @@ void Tank::update_position() {
 
 std::optional<Missle> Tank::shoot() { return mTower.shoot(); }
 
-float Tank::get_current_speed() { return mEngine->get_current_speed(); }
+float Tank::get_current_speed() const { return mEngine->get_current_speed(); }
 
 float Tank::get_tower_rotation() const { return mTower.get_rotation(); }
 

--- a/src/Tank/Tank.hpp
+++ b/src/Tank/Tank.hpp
@@ -5,41 +5,28 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "Engine.hpp"
+#include "Missle.hpp"
+#include "Tank/TankPart.hpp"
+#include "Tank/TankTower.hpp"
 #include "TextureStore.hpp"
 #include "TracesHandler.hpp"
-
-enum class Rotation { None, Clockwise, Counterclockwise };
-
-class TankPart {
- public:
-  explicit TankPart(sf::Texture& texture);
-
-  void rotate(Rotation r);
-  void set_rotation(float angle);
-  void draw(sf::RenderWindow& window, float x, float y);
-  float get_rotation() const;
-  sf::Sprite& get_sprite();
-  const sf::Sprite& get_sprite() const;
-  void update();
-
- private:
-  sf::Sprite mSprite;
-  Rotation mRotation = Rotation::None;
-};
 
 struct TankTextures {
   std::reference_wrapper<sf::Texture> mBody;
   std::reference_wrapper<sf::Texture> mTower;
   std::reference_wrapper<sf::Texture> mShot;
   std::reference_wrapper<sf::Texture> mTracks;
+  std::reference_wrapper<sf::Texture> mMissile;
 };
 
 class Tank {
  public:
   Tank(float x, float y, const TankTextures& textures, std::unique_ptr<Engine>&& engine,
-       const TracesHandlerConfig& traces_handler_config = TracesHandlerConfig{});
+       const TracesHandlerConfig& traces_handler_config = {},
+       const std::chrono::milliseconds& shot_cooldown = std::chrono::milliseconds{500});
   Tank(const Tank& rhs);
   Tank(Tank&& rhs) noexcept;
   Tank& operator=(const Tank& rhs);
@@ -53,7 +40,7 @@ class Tank {
   void set_gear(Gear gear);
   void draw(sf::RenderWindow& window);
   void update();
-  void shot();
+  std::optional<Missle> shot();
 
   [[nodiscard]] float get_tower_rotation() const;
   [[nodiscard]] sf::Vector2f get_position();
@@ -61,20 +48,14 @@ class Tank {
   [[nodiscard]] float get_current_speed();
 
  private:
-  inline constexpr static float M_SPEED = 0.01f;
-  void update_shot();
-  void update_position();
-  void draw_shot(sf::RenderWindow& window);
   void draw_tracks(sf::RenderWindow& window);
+  void update_position();
 
   sf::Vector2f mPos;
   float mCurrentSpeed = 0.0f;
-  std::chrono::system_clock::time_point mShotStart;
-  bool mDrawShot = false;
 
   TankPart mBody;
-  TankPart mTower;
-  TankPart mShot;
+  TankTower mTower;
   std::unique_ptr<Engine> mEngine;
   std::unique_ptr<TracesHandler> mTracesHandler;
 };

--- a/src/Tank/Tank.hpp
+++ b/src/Tank/Tank.hpp
@@ -11,7 +11,6 @@
 #include "Missle.hpp"
 #include "Tank/TankPart.hpp"
 #include "Tank/TankTower.hpp"
-#include "TextureStore.hpp"
 #include "TracesHandler.hpp"
 
 struct TankTextures {
@@ -43,9 +42,9 @@ class Tank {
 
   [[nodiscard]] std::optional<Missle> shoot();
   [[nodiscard]] float get_tower_rotation() const;
-  [[nodiscard]] sf::Vector2f get_position();
+  [[nodiscard]] sf::Vector2f get_position() const;
   [[nodiscard]] sf::FloatRect get_body_rect() const;
-  [[nodiscard]] float get_current_speed();
+  [[nodiscard]] float get_current_speed() const;
 
  private:
   void draw_tracks(sf::RenderWindow& window);

--- a/src/Tank/Tank.hpp
+++ b/src/Tank/Tank.hpp
@@ -40,8 +40,8 @@ class Tank {
   void set_gear(Gear gear);
   void draw(sf::RenderWindow& window);
   void update();
-  std::optional<Missle> shot();
 
+  [[nodiscard]] std::optional<Missle> shot();
   [[nodiscard]] float get_tower_rotation() const;
   [[nodiscard]] sf::Vector2f get_position();
   [[nodiscard]] sf::FloatRect get_body_rect() const;

--- a/src/Tank/Tank.hpp
+++ b/src/Tank/Tank.hpp
@@ -41,7 +41,7 @@ class Tank {
   void draw(sf::RenderWindow& window);
   void update();
 
-  [[nodiscard]] std::optional<Missle> shot();
+  [[nodiscard]] std::optional<Missle> shoot();
   [[nodiscard]] float get_tower_rotation() const;
   [[nodiscard]] sf::Vector2f get_position();
   [[nodiscard]] sf::FloatRect get_body_rect() const;

--- a/src/Tank/TankFactory.cpp
+++ b/src/Tank/TankFactory.cpp
@@ -18,11 +18,15 @@ Tank TankFactory::Random(TextureStore& store, float x, float y) {
   auto& tracks_texture = store.get_texture("tracksSmall.png", TRACKS_TEXTURE_RECT);
   tracks_texture.setSmooth(true);
   tracks_texture.setRepeated(true);
+  auto& missile_texture = store.get_texture("bulletDark3.png");
+  missile_texture.setSmooth(true);
+
   return {x, y,
           TankTextures{.mBody = body_texture,
                        .mTower = tower_texture,
                        .mShot = shot_texture,
-                       .mTracks = tracks_texture},
+                       .mTracks = tracks_texture,
+                       .mMissile = missile_texture},
           std::make_unique<SquareRootEngine>(
               SquareRootEngineConfig{.mStepCount = 70, .mMaxSpeed = 5.f}),
           TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f}};

--- a/src/Tank/TankFactory.cpp
+++ b/src/Tank/TankFactory.cpp
@@ -2,8 +2,10 @@
 
 #include "Random.hpp"
 #include "SquareRootEngine.hpp"
+#include "Tank/Tank.hpp"
+#include "TextureStore.hpp"
 
-Tank TankFactory::Random(TextureStore& store, float x, float y) {
+std::unique_ptr<Tank> TankFactory::Random(TextureStore& store, const float x, const float y) {
   using namespace std::string_literals;
   const sf::IntRect TRACKS_TEXTURE_RECT = {0, 0, 37, 48};
   auto& body_texture = store.get_texture(one_of("tankBody_red.png"s, "tankBody_dark.png"s,
@@ -21,13 +23,13 @@ Tank TankFactory::Random(TextureStore& store, float x, float y) {
   auto& missile_texture = store.get_texture("bulletDark3.png");
   missile_texture.setSmooth(true);
 
-  return {x, y,
-          TankTextures{.mBody = body_texture,
-                       .mTower = tower_texture,
-                       .mShot = shot_texture,
-                       .mTracks = tracks_texture,
-                       .mMissile = missile_texture},
-          std::make_unique<SquareRootEngine>(
-              SquareRootEngineConfig{.mStepCount = 70, .mMaxSpeed = 5.f}),
-          TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f}};
+  return std::make_unique<Tank>(x, y,
+                                TankTextures{.mBody = body_texture,
+                                             .mTower = tower_texture,
+                                             .mShot = shot_texture,
+                                             .mTracks = tracks_texture,
+                                             .mMissile = missile_texture},
+                                std::make_unique<SquareRootEngine>(
+                                    SquareRootEngineConfig{.mStepCount = 70, .mMaxSpeed = 5.f}),
+                                TracesHandlerConfig{.mMaxTraceAge = 50, .mDecayRate = 0.1f});
 }

--- a/src/Tank/TankFactory.hpp
+++ b/src/Tank/TankFactory.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <Tank/Tank.hpp>
+#include <memory>
 
 class TextureStore;
+class Tank;
 class TankFactory {
  public:
-  [[nodiscard]] static Tank Random(TextureStore& store, float x, float y);
+  [[nodiscard]] static std::unique_ptr<Tank> Random(TextureStore& store, float x, float y);
 };

--- a/src/Tank/TankFactory.hpp
+++ b/src/Tank/TankFactory.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <Tank.hpp>
+#include <Tank/Tank.hpp>
 
 class TextureStore;
 class TankFactory {

--- a/src/Tank/TankPart.cpp
+++ b/src/Tank/TankPart.cpp
@@ -1,0 +1,36 @@
+#include "TankPart.hpp"
+
+#include <gsl/gsl>
+
+constexpr int TANK_PART_ROTATE = 10;
+
+TankPart::TankPart(sf::Texture &texture) {
+  mSprite.setTexture(texture);
+  const auto [width, height] = texture.getSize();
+  mSprite.setOrigin(gsl::narrow<float>(width) / 2.f, gsl::narrow<float>(height) / 2.f);
+}
+
+void TankPart::rotate(const Rotation r) { mRotation = r; }
+
+void TankPart::set_rotation(const float angle) { mSprite.setRotation(angle); }
+
+float TankPart::get_rotation() const { return mSprite.getRotation(); }
+
+sf::Sprite &TankPart::get_sprite() { return mSprite; }
+
+const sf::Sprite &TankPart::get_sprite() const { return mSprite; }
+
+void TankPart::update() {
+  switch (mRotation) {
+    case Rotation::Clockwise:
+      mSprite.rotate(TANK_PART_ROTATE);
+      break;
+    case Rotation::Counterclockwise:
+      mSprite.rotate(-TANK_PART_ROTATE);
+      break;
+    case Rotation::None:
+      break;
+  }
+}
+
+void TankPart::draw(sf::RenderWindow &window) { window.draw(mSprite); }

--- a/src/Tank/TankPart.hpp
+++ b/src/Tank/TankPart.hpp
@@ -11,10 +11,11 @@ class TankPart {
   void rotate(Rotation r);
   void set_rotation(float angle);
   void draw(sf::RenderWindow& window);
-  float get_rotation() const;
-  sf::Sprite& get_sprite();
-  const sf::Sprite& get_sprite() const;
   void update();
+
+  [[nodiscard]] float get_rotation() const;
+  [[nodiscard]] sf::Sprite& get_sprite();
+  [[nodiscard]] const sf::Sprite& get_sprite() const;
 
  private:
   sf::Sprite mSprite;

--- a/src/Tank/TankPart.hpp
+++ b/src/Tank/TankPart.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+
+enum class Rotation { None, Clockwise, Counterclockwise };
+
+class TankPart {
+ public:
+  explicit TankPart(sf::Texture& texture);
+
+  void rotate(Rotation r);
+  void set_rotation(float angle);
+  void draw(sf::RenderWindow& window);
+  float get_rotation() const;
+  sf::Sprite& get_sprite();
+  const sf::Sprite& get_sprite() const;
+  void update();
+
+ private:
+  sf::Sprite mSprite;
+  Rotation mRotation = Rotation::None;
+};

--- a/src/Tank/TankTower.cpp
+++ b/src/Tank/TankTower.cpp
@@ -14,7 +14,6 @@ TankTower::TankTower(const TankTowerTextures& textures,
     : mTower(textures.mTower),
       mShotAnimation(textures.mShotAnimation),
       mMissileTexture(textures.mMissile),
-      mLastShot(std::chrono::system_clock::now()),
       mShotCooldown(shot_cooldown) {}
 
 void TankTower::set_position(const sf::Vector2f& pos) {

--- a/src/Tank/TankTower.cpp
+++ b/src/Tank/TankTower.cpp
@@ -1,0 +1,79 @@
+#include "TankTower.hpp"
+
+#include <gsl/gsl>
+
+#include "utility.hpp"
+
+constexpr int ROTATION_OFFSET = 90;
+constexpr int SHOT_ANIMATION_DISTANCE = 30;
+constexpr std::chrono::milliseconds SHOT_ANIMATION_DURATION = std::chrono::milliseconds(100);
+constexpr auto SHOT_COOLDOWN = std::chrono::milliseconds{500};
+
+TankTower::TankTower(const TankTowerTextures& textures,
+                     const std::chrono::milliseconds& shot_cooldown)
+    : mTower(textures.mTower),
+      mShotAnimation(textures.mShotAnimation),
+      mMissileTexture(textures.mMissile),
+      mLastShot(std::chrono::system_clock::now()),
+      mShotCooldown(shot_cooldown) {}
+
+void TankTower::set_position(const sf::Vector2f& pos) {
+  mTower.get_sprite().setPosition(pos);
+  mShotAnimation.get_sprite().setPosition(calculate_shot_position());
+}
+
+sf::Vector2f TankTower::calculate_shot_position() const {
+  const auto tower_rotation = mTower.get_rotation();
+  const auto& [x, y] = mTower.get_sprite().getPosition();
+  return sf::Vector2f{
+      x + SHOT_ANIMATION_DISTANCE *
+              gsl::narrow_cast<float>(cos(to_radians(tower_rotation - ROTATION_OFFSET))),
+      y + SHOT_ANIMATION_DISTANCE *
+              gsl::narrow_cast<float>(sin(to_radians(tower_rotation - ROTATION_OFFSET)))};
+}
+
+void TankTower::set_rotation(float angle) {
+  mTower.set_rotation(angle);
+  mShotAnimation.set_rotation(angle);
+}
+
+void TankTower::rotate(Rotation r) {
+  mTower.rotate(r);
+  mShotAnimation.rotate(r);
+}
+
+void TankTower::draw(sf::RenderWindow& window) {
+  mTower.draw(window);
+  if (mDrawShot) {
+    mShotAnimation.draw(window);
+  }
+}
+
+void TankTower::update() {
+  mTower.update();
+  mShotAnimation.update();
+  update_shot_time();
+}
+
+void TankTower::update_shot_time() {
+  auto now = std::chrono::system_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
+  if (elapsed > SHOT_ANIMATION_DURATION) {
+    mDrawShot = false;
+  }
+}
+
+std::optional<Missle> TankTower::shot() {
+  auto now = std::chrono::system_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
+  if (elapsed >= mShotCooldown) {
+    mLastShot = std::chrono::system_clock::now();
+    mDrawShot = true;
+    const auto& [x, y] = calculate_shot_position();
+    return std::make_optional<Missle>(
+        mMissileTexture, MovementState{.mX = x, .mY = y, .mAngle = mTower.get_rotation()});
+  }
+  return std::nullopt;
+}
+
+float TankTower::get_rotation() const { return mTower.get_rotation(); }

--- a/src/Tank/TankTower.cpp
+++ b/src/Tank/TankTower.cpp
@@ -62,7 +62,7 @@ void TankTower::update_shot_time() {
   }
 }
 
-std::optional<Missle> TankTower::shot() {
+std::optional<Missle> TankTower::shoot() {
   auto now = std::chrono::system_clock::now();
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastShot);
   if (elapsed >= mShotCooldown) {

--- a/src/Tank/TankTower.hpp
+++ b/src/Tank/TankTower.hpp
@@ -24,7 +24,7 @@ class TankTower {
   void draw(sf::RenderWindow& window);
   void update();
 
-  [[nodiscard]] std::optional<Missle> shot();
+  [[nodiscard]] std::optional<Missle> shoot();
   [[nodiscard]] float get_rotation() const;
 
  private:

--- a/src/Tank/TankTower.hpp
+++ b/src/Tank/TankTower.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <chrono>
+#include <functional>
+#include <optional>
+
+#include "Missle.hpp"
+#include "SFML/Graphics.hpp"
+#include "Tank/TankPart.hpp"
+
+struct TankTowerTextures {
+  std::reference_wrapper<sf::Texture> mTower;
+  std::reference_wrapper<sf::Texture> mShotAnimation;
+  std::reference_wrapper<sf::Texture> mMissile;
+};
+
+class TankTower {
+ public:
+  TankTower(const TankTowerTextures& textures, const std::chrono::milliseconds& shot_cooldown);
+
+  void set_position(const sf::Vector2f& pos);
+  void set_rotation(float angle);
+  void rotate(Rotation r);
+
+  void draw(sf::RenderWindow& window);
+  void update();
+
+  [[nodiscard]] std::optional<Missle> shot();
+  [[nodiscard]] float get_rotation() const;
+
+ private:
+  sf::Vector2f calculate_shot_position() const;
+  void update_shot_time();
+
+  TankPart mTower;
+  TankPart mShotAnimation;
+  std::reference_wrapper<sf::Texture> mMissileTexture;
+  std::chrono::time_point<std::chrono::system_clock> mLastShot;
+  std::chrono::milliseconds mShotCooldown;
+  bool mDrawShot = false;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 
 int main() {
   Board b;
-  b.register_tank();
   b.run();
   return 0;
 }

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -67,15 +67,3 @@ inline void print_point(const auto& point) {
   }
   return opposite_angle;
 }
-
-template <typename Iter, typename Pred>
-requires std::input_iterator<Iter>&& std::indirect_unary_predicate<Pred, Iter> std::vector<Iter>
-find_all(Iter cbegin, Iter cend, Pred pred) {
-  std::vector<Iter> elements{};
-  for (; cbegin != cend; ++cbegin) {
-    if (pred(*cbegin)) {
-      elements.push_back(cbegin);
-    }
-  }
-  return elements;
-}

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <gsl/gsl>
 #include <iostream>
+#include <iterator>
 
 #include "Size.hpp"
 
@@ -65,4 +66,16 @@ inline void print_point(const auto& point) {
     opposite_angle = 360.f + opposite_angle;
   }
   return opposite_angle;
+}
+
+template <typename Iter, typename Pred>
+requires std::input_iterator<Iter>&& std::indirect_unary_predicate<Pred, Iter> std::vector<Iter>
+find_all(Iter cbegin, Iter cend, Pred pred) {
+  std::vector<Iter> elements{};
+  for (; cbegin != cend; ++cbegin) {
+    if (pred(*cbegin)) {
+      elements.push_back(cbegin);
+    }
+  }
+  return elements;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(run_tests
   TestUtility.cpp
   UtilityTests.cpp
   TracesHandlerTests.cpp
+  TankPartTests.cpp
 )
 
 target_include_directories(run_tests PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(run_tests
   UtilityTests.cpp
   TracesHandlerTests.cpp
   TankPartTests.cpp
+  TankTowerTests.cpp
 )
 
 target_include_directories(run_tests PRIVATE

--- a/test/TankPartTests.cpp
+++ b/test/TankPartTests.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "Tank/TankPart.hpp"
+#include "TestUtility.hpp"
+
+class TankPartTest : public ::testing::Test {
+ public:
+  std::unique_ptr<sf::Texture> mTexture{create_dummy_texture()};
+  TankPart mPart{*mTexture};
+  TankPartTest() {
+    constexpr float INITIAL_ROTATION = 100.f;
+    mPart.set_rotation(INITIAL_ROTATION);
+  }
+};
+
+TEST_F(TankPartTest, GivenRotateClockwise_WhenUpdateCalled_ThenRotationShouldBeIncreased) {
+  const auto& original_rotation = mPart.get_rotation();
+  mPart.rotate(Rotation::Clockwise);
+  mPart.update();
+  EXPECT_GT(mPart.get_rotation(), original_rotation);
+}
+
+TEST_F(TankPartTest, GivenRotateCounterclockwise_WhenUpdateCalled_ThenRotationShouldBeDecreased) {
+  const auto& original_rotation = mPart.get_rotation();
+  mPart.rotate(Rotation::Counterclockwise);
+  mPart.update();
+  EXPECT_LT(mPart.get_rotation(), original_rotation);
+}
+
+TEST_F(TankPartTest, GivenRotateNone_WhenUpdateCalled_ThenRotationShouldNotChange) {
+  const auto& original_rotation = mPart.get_rotation();
+  mPart.rotate(Rotation::None);
+  mPart.update();
+  EXPECT_NEAR(mPart.get_rotation(), original_rotation, PRECISION);
+}

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -18,40 +18,33 @@ struct EngineMock : Engine {
   MOCK_METHOD(void, update, (), (override));
 };
 
-struct TankTest : ::testing::Test {
+struct TankTestData {
   std::unique_ptr<sf::Texture> mBody{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mTower{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mShot{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mTracks{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mMissile{create_dummy_texture()};
+  TankTextures mTextures{.mBody = *mBody,
+                         .mTower = *mTower,
+                         .mShot = *mShot,
+                         .mTracks = *mTracks,
+                         .mMissile = *mMissile};
   std::unique_ptr<testing::NiceMock<EngineMock>> mEngine{
       std::make_unique<testing::NiceMock<EngineMock>>()};
   std::shared_ptr<testing::NiceMock<EngineMock>> mEngineNiceMock{
       std::shared_ptr<testing::NiceMock<EngineMock>>{}, mEngine.get()};
+
+  Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
+    return {0, 0, mTextures, std::move(engine),
+            TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
+  }
+};
+
+struct TankTest : TankTestData, ::testing::Test {
   Tank mTankSUT{create_tank(std::move(mEngine))};
 
   float mSpeed{1.f};
   int mAngle{90};
-
-  Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
-    return {0, 0,
-            TankTextures{.mBody = *mBody,
-                         .mTower = *mTower,
-                         .mShot = *mShot,
-                         .mTracks = *mTracks,
-                         .mMissile = *mMissile},
-            std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
-  }
-
-  Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
-    return {0, 0,
-            TankTextures{.mBody = *mBody,
-                         .mTower = *mTower,
-                         .mShot = *mShot,
-                         .mTracks = *mTracks,
-                         .mMissile = *mMissile},
-            std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
-  }
 };
 
 TEST_F(TankTest, GivenAngleRotationWhenUpdateThenShouldCallGetPositionDeltaWithAngleRotation) {
@@ -111,3 +104,19 @@ TEST_F(TankTest, WhenTankIsOneAxisOutOfTheBoard_ThenShouldAllowToMoveOnlyOneAxis
 
   expect_vec2f_eq({0.f, 500.f}, mTankSUT.get_position());
 }
+
+struct TankShootingTest : TankTestData, ::testing::TestWithParam<float> {
+  Tank mTankSUT{create_tank(std::move(mEngine))};
+};
+
+TEST_P(TankShootingTest, GivenAnyRotation_WhenTankShoots_ThenTankBodyShouldNotContainMissile) {
+  const auto rotation = GetParam();
+  mTankSUT.set_rotation(rotation);
+  const auto& missile = mTankSUT.shot();
+
+  EXPECT_FALSE(mTankSUT.get_body_rect().contains(missile->get_pos()));
+}
+
+INSTANTIATE_TEST_SUITE_P(TankShootingTestsWithManyValues, TankShootingTest,
+                         testing::Values(0.f, 30.f, 45.f, 60.f, 90.f, 135.f, 180.f, 225.f, 270.f,
+                                         315.f, 359.f));

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -4,7 +4,7 @@
 #include <utility>
 
 #include "SquareRootEngine.hpp"
-#include "Tank.hpp"
+#include "Tank/Tank.hpp"
 #include "TestUtility.hpp"
 #include "TracesHandler.hpp"
 #include "gmock/gmock.h"
@@ -23,6 +23,7 @@ struct TankTest : ::testing::Test {
   std::unique_ptr<sf::Texture> mTower{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mShot{create_dummy_texture()};
   std::unique_ptr<sf::Texture> mTracks{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mMissile{create_dummy_texture()};
   std::unique_ptr<testing::NiceMock<EngineMock>> mEngine{
       std::make_unique<testing::NiceMock<EngineMock>>()};
   std::shared_ptr<testing::NiceMock<EngineMock>> mEngineNiceMock{
@@ -34,13 +35,21 @@ struct TankTest : ::testing::Test {
 
   Tank create_tank(std::unique_ptr<testing::NiceMock<EngineMock>>&& engine) {
     return {0, 0,
-            TankTextures{.mBody = *mBody, .mTower = *mTower, .mShot = *mShot, .mTracks = *mTracks},
+            TankTextures{.mBody = *mBody,
+                         .mTower = *mTower,
+                         .mShot = *mShot,
+                         .mTracks = *mTracks,
+                         .mMissile = *mMissile},
             std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
   }
 
   Tank create_tank(std::unique_ptr<testing::StrictMock<EngineMock>>&& engine) {
     return {0, 0,
-            TankTextures{.mBody = *mBody, .mTower = *mTower, .mShot = *mShot, .mTracks = *mTracks},
+            TankTextures{.mBody = *mBody,
+                         .mTower = *mTower,
+                         .mShot = *mShot,
+                         .mTracks = *mTracks,
+                         .mMissile = *mMissile},
             std::move(engine), TracesHandlerConfig{.mMaxTraceAge = 10, .mDecayRate = 0.1f}};
   }
 };

--- a/test/TankTests.cpp
+++ b/test/TankTests.cpp
@@ -112,7 +112,7 @@ struct TankShootingTest : TankTestData, ::testing::TestWithParam<float> {
 TEST_P(TankShootingTest, GivenAnyRotation_WhenTankShoots_ThenTankBodyShouldNotContainMissile) {
   const auto rotation = GetParam();
   mTankSUT.set_rotation(rotation);
-  const auto& missile = mTankSUT.shot();
+  const auto& missile = mTankSUT.shoot();
 
   EXPECT_FALSE(mTankSUT.get_body_rect().contains(missile->get_pos()));
 }

--- a/test/TankTowerTests.cpp
+++ b/test/TankTowerTests.cpp
@@ -16,14 +16,14 @@ class TankTowerTest : public ::testing::Test {
 
 TEST_F(TankTowerTest, Given0MsCooldown_WhenShotCalled_ThenMissileIsAlwaysReturned) {
   TankTower mTower{mTextures, std::chrono::milliseconds{0}};
-  EXPECT_TRUE(mTower.shot());
-  EXPECT_TRUE(mTower.shot());
-  EXPECT_TRUE(mTower.shot());
+  EXPECT_TRUE(mTower.shoot());
+  EXPECT_TRUE(mTower.shoot());
+  EXPECT_TRUE(mTower.shoot());
 }
 
 TEST_F(TankTowerTest, GivenNonZeroCooldown_WhenShotCalled_ThenMissileIsNotAlwaysReturned) {
   TankTower mTower{mTextures, std::chrono::milliseconds{500}};
-  EXPECT_TRUE(mTower.shot());
-  EXPECT_FALSE(mTower.shot());
-  EXPECT_FALSE(mTower.shot());
+  EXPECT_TRUE(mTower.shoot());
+  EXPECT_FALSE(mTower.shoot());
+  EXPECT_FALSE(mTower.shoot());
 }

--- a/test/TankTowerTests.cpp
+++ b/test/TankTowerTests.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "Tank/TankTower.hpp"
+#include "TestUtility.hpp"
+
+class TankTowerTest : public ::testing::Test {
+ public:
+  std::unique_ptr<sf::Texture> mTowerTex{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mShotTex{create_dummy_texture()};
+  std::unique_ptr<sf::Texture> mMissileTex{create_dummy_texture()};
+  TankTowerTextures mTextures{
+      .mTower = *mTowerTex, .mShotAnimation = *mShotTex, .mMissile = *mMissileTex};
+};
+
+TEST_F(TankTowerTest, Given0MsCooldown_WhenShotCalled_ThenMissileIsAlwaysReturned) {
+  TankTower mTower{mTextures, std::chrono::milliseconds{0}};
+  EXPECT_TRUE(mTower.shot());
+  EXPECT_TRUE(mTower.shot());
+  EXPECT_TRUE(mTower.shot());
+}
+
+TEST_F(TankTowerTest, GivenNonZeroCooldown_WhenShotCalled_ThenMissileIsNotAlwaysReturned) {
+  TankTower mTower{mTextures, std::chrono::milliseconds{500}};
+  EXPECT_TRUE(mTower.shot());
+  EXPECT_FALSE(mTower.shot());
+  EXPECT_FALSE(mTower.shot());
+}

--- a/test/TestUtility.hpp
+++ b/test/TestUtility.hpp
@@ -1,11 +1,31 @@
 #pragma once
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/System/Vector2.hpp>
+#include <iterator>
 #include <memory>
 #include <range/v3/view/iota.hpp>
 
 inline constexpr double PRECISION{0.0001};
 void expect_vec2f_eq(const sf::Vector2f& lhs, const sf::Vector2f& rhs);
+
+template <typename T>
+void expect_vec_eq(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+  ASSERT_EQ(lhs.size(), rhs.size());
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    EXPECT_EQ(lhs[i], rhs[i]);
+  }
+}
+
+template <typename Iter>
+requires std::input_iterator<Iter> std::vector<std::iter_value_t<Iter>> dereference_vec(
+    const std::vector<Iter>& vec) {
+  std::vector<std::iter_value_t<Iter>> result{};
+  for (const auto& iter : vec) {
+    result.push_back(*iter);
+  }
+  return result;
+}
+
 std::unique_ptr<sf::Texture> create_dummy_texture(unsigned int = 5, unsigned int = 5);
 
 template <typename T>

--- a/test/TextureStoreTests.cpp
+++ b/test/TextureStoreTests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <stdexcept>
+#include <tuple>
 
 #include "TextureStore.hpp"
 
@@ -9,7 +10,7 @@ struct TextureStoreTest : ::testing::Test {
 };
 
 TEST_F(TextureStoreTest, NonExistingSprite_ShouldThrowException) {
-  EXPECT_THROW(mTextureStore.get_texture("not_existing"), std::runtime_error);
+  EXPECT_THROW(std::ignore = mTextureStore.get_texture("not_existing"), std::runtime_error);
 }
 
 TEST_F(TextureStoreTest, GetSameTextureTwice_ShouldHaveTheSameAddress) {

--- a/test/UtilityTests.cpp
+++ b/test/UtilityTests.cpp
@@ -55,3 +55,27 @@ TEST(GetAngleTest, GetAngleShouldComplementGetPositionDelta) {
 
   EXPECT_NEAR(actual_angle_degrees, to_degrees(expected_angle_radians), PRECISION);
 }
+
+TEST(FindAllTest, GivenNoElementsFoundInRange_WhenFindAllCalled_ThenReturnEmptyVector) {
+  std::vector<int> collection{1, 3, 5};
+  const auto& iters =
+      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val % 2 == 0; });
+  const auto& elems = dereference_vec(iters);
+  expect_vec_eq(elems, std::vector<int>{});
+}
+
+TEST(FindAllTest, GivenOneElementFoundInRange_WhenFindAllCalled_ThenReturnOneIterator) {
+  std::vector<int> collection{1, 3, 5};
+  const auto& iters =
+      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val == 5; });
+  const auto& elems = dereference_vec(iters);
+  expect_vec_eq(elems, std::vector<int>{5});
+}
+
+TEST(FindAllTest, GivenMultipleElementsFoundInRange_WhenFindAllCalled_ThenReturnAllIterators) {
+  std::vector<int> collection{1, 2, 3, 4, 5, 6};
+  const auto& iters =
+      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val % 2 == 0; });
+  const auto& elems = dereference_vec(iters);
+  expect_vec_eq(elems, std::vector<int>{2, 4, 6});
+}

--- a/test/UtilityTests.cpp
+++ b/test/UtilityTests.cpp
@@ -55,27 +55,3 @@ TEST(GetAngleTest, GetAngleShouldComplementGetPositionDelta) {
 
   EXPECT_NEAR(actual_angle_degrees, to_degrees(expected_angle_radians), PRECISION);
 }
-
-TEST(FindAllTest, GivenNoElementsFoundInRange_WhenFindAllCalled_ThenReturnEmptyVector) {
-  std::vector<int> collection{1, 3, 5};
-  const auto& iters =
-      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val % 2 == 0; });
-  const auto& elems = dereference_vec(iters);
-  expect_vec_eq(elems, std::vector<int>{});
-}
-
-TEST(FindAllTest, GivenOneElementFoundInRange_WhenFindAllCalled_ThenReturnOneIterator) {
-  std::vector<int> collection{1, 3, 5};
-  const auto& iters =
-      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val == 5; });
-  const auto& elems = dereference_vec(iters);
-  expect_vec_eq(elems, std::vector<int>{5});
-}
-
-TEST(FindAllTest, GivenMultipleElementsFoundInRange_WhenFindAllCalled_ThenReturnAllIterators) {
-  std::vector<int> collection{1, 2, 3, 4, 5, 6};
-  const auto& iters =
-      find_all(collection.cbegin(), collection.cend(), [](const int val) { return val % 2 == 0; });
-  const auto& elems = dereference_vec(iters);
-  expect_vec_eq(elems, std::vector<int>{2, 4, 6});
-}


### PR DESCRIPTION
This PR resolves #7. When Tank gets hit by a Missile, both Tank & Missile are removed.

- Board manages players instead of tanks
- Tanks & Controllers are managed by Players
- Board::register_tank function removed (acted like a second constructor)
- TankFactory returns std::unique_ptr instead of entire Tank object
- Tank is refactored
  - TankTower created (manages shot animation, missile generation, shot cooldown, tower rotation)
  - TankPart is now in seperate file
  - new folder to keep Tank related stuff together
  - shot cooldown is configurable as a Tank parameter 
  - tests added for Tank related classes
  - shot method renamed to shoot (shoot is a verb, shot is past form)
  - const qualifiers added to some methods
- TextureStore compilation warning is fixed by using `std::ignore` 