### PR TITLE
Update vcpkg submodule

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tank-bot-fight",
   "version-string": "0.0.1",
-  "builtin-baseline": "50fd3d9957195575849a49fa591e645f1d8e7156",
+  "builtin-baseline": "c37cc7836a0e1cfd55747be8ec472eafa8055276",
   "dependencies": [
     "sfml",
     "ms-gsl",


### PR DESCRIPTION
This is important because of this issue: https://github.com/microsoft/vcpkg/issues/23828

MSYS2 repositories often invalidate their packages and previous version of vcpkg used dead-links now.